### PR TITLE
Fix solver! when T=Float32

### DIFF
--- a/examples/TandemFoilOptim.jl
+++ b/examples/TandemFoilOptim.jl
@@ -35,6 +35,7 @@ function two_foil_drag(φ,St=0.3)
     period = 2/St
     cost = -mean_thrust(make_foils(φ;St),range(period,2period,200))
     @show φ,cost
+    return cost
 end
 res = optimize(x->two_foil_drag(first(x)),[2f0],Adam(alpha=0.5,beta_mean=0.5,beta_var=0.5),
         Optim.Options(iterations = 10);autodiff = :forward)

--- a/examples/TandemFoilOptim.jl
+++ b/examples/TandemFoilOptim.jl
@@ -1,18 +1,16 @@
 using WaterLily,StaticArrays
 
-function make_foils(φ;two=true,L=32,Re=1e3,St=0.3,αₘ=-π/18,U=1,n=8,m=4)
+function make_foils(φ;two=true,L=64,Re=200,St=0.3,αₘ=-π/18,U=1,n=8,m=4,T=typeof(φ))
     # Map from simulation coordinate x to surface coordinate ξ
-    nose,pivot = SA[2L,m*L//2],SA[L//4,0]
-    θ₀ = αₘ+atan(π*St); h₀=L; ω=π*St*U/h₀
+    nose,pivot = SA[2L,m*L÷2],SA[L÷4,0]
+    θ₀ = T(αₘ+atan(π*St)); h₀=L; ω = T(π*St*U/h₀)
     function map(x,t)
         back = two && x[1]>nose[1]+2L # back body?
         ϕ = back ? φ : zero(φ)        # phase shift
         S = back ? 3L : zero(L)       # horizontal shift
         s,c = sincos(θ₀*cos(ω*t+ϕ))   # sin & cos of angle
         h = SA[S,h₀*sin(ω*t+ϕ)]       # position
-        # move to origin and align with x-axis
-        ξ = SA[c -s; s c]*(x-nose-h-pivot)+pivot 
-        return SA[ξ[1],abs(ξ[2])]    # reflect to positive y
+        SA[c -s; s c]*(x-nose-h-pivot)+pivot 
     end
 
     # Line segment SDF
@@ -24,7 +22,7 @@ function make_foils(φ;two=true,L=32,Re=1e3,St=0.3,αₘ=-π/18,U=1,n=8,m=4)
     Simulation((n*L,m*L),(U,0),L;ν=U*L/Re,body=AutoBody(sdf,map),T=typeof(φ))
 end
 
-drag(flow,body,t) = sum(inside(flow.p)) do I
+thrust(flow,body,t) = sum(inside(flow.p)) do I
     d,n,_ = measure(body,WaterLily.loc(0,I),t)
     flow.p[I]*n[1]*WaterLily.kern(clamp(d,-1,1))
 end
@@ -32,7 +30,7 @@ end
 function Δimpulse!(sim)
     Δt = sim.flow.Δt[end]*sim.U/sim.L
     sim_step!(sim)
-    Δt*drag(sim.flow,sim.body,WaterLily.time(sim))
+    Δt*thrust(sim.flow,sim.body,WaterLily.time(sim))
 end
 
 function mean_drag(φ,two=true,St=0.3,N=3,period=2N/St)
@@ -42,9 +40,9 @@ function mean_drag(φ,two=true,St=0.3,N=3,period=2N/St)
     while sim_time(sim)<2period
         impulse += Δimpulse!(sim)
     end
-    impulse/period        # return mean drag
+    impulse/period        # return mean thrust
 end
 
 using Optim
-θ = Optim.minimizer(optimize(x->-mean_drag(first(x)), [0f0], Newton(),
+θ = Optim.minimizer(optimize(x->-mean_thrust(first(x)), [0f0], Newton(),
     Optim.Options(show_trace=true,f_tol=1e-2); autodiff = :forward))

--- a/ext/WaterLilyAMDGPUExt.jl
+++ b/ext/WaterLilyAMDGPUExt.jl
@@ -7,7 +7,7 @@ else
 end
 
 using WaterLily
-import WaterLily: L₂
+import WaterLily: ⋅, L₂
 
 """
     __init__()
@@ -18,6 +18,19 @@ __init__() = @assert AMDGPU.functional()
 
 AMDGPU.allowscalar(false) # disallow scalar operations on GPU
 
+"""
+    ⋅(a,b)
+
+Dot product of `a` and `b` `ROCArray`s reducing over a `Float64`.
+
+[NOT TESTED]
+"""
+function ⋅(a::ROCArray, b::ROCArray)
+    @assert size(a) == size(b) "`size(a)` and `size(b)` are not matching."
+    mapreduce(+, a, b) do x, y
+        promote_type(Float64,eltype(a))(x*y)
+    end
+end
 """
     L₂(a)
 

--- a/ext/WaterLilyCUDAExt.jl
+++ b/ext/WaterLilyCUDAExt.jl
@@ -7,7 +7,7 @@ else
 end
 
 using WaterLily
-import WaterLily: L₂
+import WaterLily: ⋅, L₂
 
 """
     __init__()
@@ -17,6 +17,18 @@ Asserts CUDA is functional when loading this extension.
 __init__() = @assert CUDA.functional()
 
 CUDA.allowscalar(false) # disallow scalar operations on GPU
+
+"""
+    ⋅(a,b)
+
+Dot product of `a` and `b` `CuArray`s reducing over a `Float64`.
+"""
+function ⋅(a::CuArray, b::CuArray)
+    @assert size(a) == size(b) "`size(a)` and `size(b)` are not matching."
+    mapreduce(+, a, b) do x, y
+        promote_type(Float64,eltype(a))(x*y)
+    end
+end
 
 """
     L₂(a)

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -96,7 +96,7 @@ pressure_force(flow,body) = pressure_force(flow.p,flow.f,body,time(flow))
 function pressure_force(p,df,body,t=0,T=promote_type(Float64,eltype(p)))
     df .= zero(eltype(p))
     @loop df[I,:] .= p[I]*nds(body,loc(0,I),t) over I ∈ inside(p)
-    sum(T,df,dims=ntuple(i->i,ndims(p)))[:] |> Array
+    sum(T,df,dims=ntuple(i->i,ndims(p)))[:] |> Array{eltype(p)}
 end
 
 """
@@ -116,7 +116,7 @@ viscous_force(flow,body) = viscous_force(flow.u,flow.ν,flow.f,body,time(flow))
 function viscous_force(u,ν,df,body,t=0,T=promote_type(Float64,eltype(u)))
     df .= zero(eltype(u))
     @loop df[I,:] .= -ν*∇²u(I,u)*nds(body,loc(0,I),t) over I ∈ inside_u(u)
-    sum(T,df,dims=ntuple(i->i,ndims(u)-1))[:] |> Array
+    sum(T,df,dims=ntuple(i->i,ndims(u)-1))[:] |> Array{eltype(u)}
 end
 
 """
@@ -137,5 +137,5 @@ pressure_moment(x₀,flow,body) = pressure_moment(x₀,flow.p,flow.f,body,time(f
 function pressure_moment(x₀,p,df,body,t=0,T=promote_type(Float64,eltype(p)))
     df .= zero(eltype(p))
     @loop df[I,:] .= p[I]*cross(loc(0,I)-x₀,nds(body,loc(0,I),t)) over I ∈ inside(p)
-    sum(T,df,dims=ntuple(i->i,ndims(p)))[:] |> Array
+    sum(T,df,dims=ntuple(i->i,ndims(p)))[:] |> Array{eltype(p)}
 end

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -134,7 +134,7 @@ function pcg!(p::Poisson{T};it=6) where T
         (i==it || abs(alpha)<1e-2) && return
         @inside z[I] = r[I]*p.iD[I]
         rho2 = r⋅z
-        abs(rho2)<10eps(T) && return
+        (abs(rho)<10eps(T) || abs(rho)<abs(rho2)) && return
         beta = rho2/rho
         @inside ϵ[I] = beta*ϵ[I]+z[I]
         rho = rho2

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -114,11 +114,11 @@ end
 
 using LinearAlgebra: ⋅
 """
-    pcg!(p::Poisson; it=6)
+    pcg!(p::Poisson; it=6, f=2)
 
 Conjugate-Gradient smoother with Jacobi preditioning. Runs at most `it` iterations, 
-but will exit early if the Gram-Schmidt update parameter `|α| < 1%` or `|r D⁻¹ r| < 1e-8`.
-Note: This runs for general backends and is the default smoother.
+but will exit early if the step-size `|α| < 1%` or residual `ρ = r'D⁻¹r < 10eps`.
+Will also exit if `ρᵏ⁺¹ ≥ fρᵏ` to avoid divergence.
 """
 function pcg!(p::Poisson{T};it=6,f=2) where T
     x,r,ϵ,z = p.x,p.r,p.ϵ,p.z

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -9,7 +9,7 @@ The resulting linear system is
 
     Ax = [L+D+L']x = z
 
-where A is symmetric, block-tridiagonal and extremely sparse. Moreover, 
+where A is symmetric, block-tridiagonal and extremely sparse. Moreover,
 `D[I]=-∑ᵢ(L[I,i]+L'[I,i])`. This means matrix storage, multiplication,
 ect can be easily implemented and optimized without external libraries.
 
@@ -56,7 +56,7 @@ end
 """
     mult!(p::Poisson,x)
 
-Efficient function for Poisson matrix-vector multiplication. 
+Efficient function for Poisson matrix-vector multiplication.
 Fills `p.z = p.A x` with 0 in the ghost cells.
 """
 function mult!(p::Poisson,x)
@@ -79,16 +79,16 @@ end
 
 Computes the resiual `r = z-Ax` and corrects it such that
 `r = 0` if `iD==0` which ensures local satisfiability
-    and 
+    and
 `sum(r) = 0` which ensures global satisfiability.
 
-The global correction is done by adjusting all points uniformly, 
+The global correction is done by adjusting all points uniformly,
 minimizing the local effect. Other approaches are possible.
 
 Note: These corrections mean `x` is not strictly solving `Ax=z`, but
 without the corrections, no solution exists.
 """
-function residual!(p::Poisson) 
+function residual!(p::Poisson)
     perBC!(p.x,p.perdir)
     @inside p.r[I] = ifelse(p.iD[I]==0,0,p.z[I]-mult(I,p.L,p.D,p.x))
     s = sum(p.r)/length(inside(p.r))
@@ -96,7 +96,7 @@ function residual!(p::Poisson)
     @inside p.r[I] = p.r[I]-s
 end
 
-function increment!(p::Poisson) 
+function increment!(p::Poisson)
     perBC!(p.ϵ,p.perdir)
     @loop (p.r[I] = p.r[I]-mult(I,p.L,p.D,p.ϵ);
            p.x[I] = p.x[I]+p.ϵ[I]) over I ∈ inside(p.x)
@@ -104,7 +104,7 @@ end
 """
     Jacobi!(p::Poisson; it=1)
 
-Jacobi smoother run `it` times. 
+Jacobi smoother run `it` times.
 Note: This runs for general backends, but is _very_ slow to converge.
 """
 @fastmath Jacobi!(p;it=1) = for _ ∈ 1:it
@@ -112,11 +112,10 @@ Note: This runs for general backends, but is _very_ slow to converge.
     increment!(p)
 end
 
-using LinearAlgebra: ⋅
 """
     pcg!(p::Poisson; it=6, f=2)
 
-Conjugate-Gradient smoother with Jacobi preditioning. Runs at most `it` iterations, 
+Conjugate-Gradient smoother with Jacobi preditioning. Runs at most `it` iterations,
 but will exit early if the step-size `|α| < 1%` or residual `ρ = r'D⁻¹r < 10eps`.
 Will also exit if `ρᵏ⁺¹ ≥ fρᵏ` to avoid divergence.
 """

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -6,7 +6,7 @@ module WaterLily
 using DocStringExtensions
 
 include("util.jl")
-export L₂,BC!,@inside,inside,δ,apply!,loc
+export ⋅,L₂,BC!,@inside,inside,δ,apply!,loc
 
 using Reexport
 @reexport using KernelAbstractions: @kernel,@index,get_backend

--- a/src/util.jl
+++ b/src/util.jl
@@ -38,6 +38,20 @@ splitn(n) = Base.front(n),last(n)
 size_u(u) = splitn(size(u))
 
 """
+    ⋅(a,b)
+
+Dot product of `a` and `b` `Array`s reducing over a `Float64`.
+"""
+function ⋅(a, b)
+    @assert size(a) == size(b) "`size(a)` and `size(b)` are not matching."
+    s = zero(promote_type(Float64,eltype(a)))
+    @simd for i ∈ eachindex(a)
+        @inbounds s += a[i]*b[i]
+    end
+    s
+end
+
+"""
     L₂(a)
 
 L₂ norm of array `a` excluding ghosts.

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -25,6 +25,10 @@ using ReadVTK, WriteVTK
         @test inside(p,buff=0) == CartesianIndices(p)
         @test L₂(p) == 187
 
+        q = 2ones(Float32,4,5) |> f
+        @test isa(⋅(q,q), Float64)
+        @test ⋅(q,q) ≈ 80.0
+
         u = zeros(5,5,2) |> f
         apply!((i,x)->x[i],u)
         @test GPUArrays.@allowscalar [u[i,j,1].-(i-2) for i in 1:3, j in 1:3]==zeros(3,3)


### PR DESCRIPTION
I have found a few dynamic body cases (including the new Optim example) where `solver!` diverges (or nearly diverges) when using `T=Float32` (or `Dual{Float32}`). I _think_ this is because the inner product within PCG is not super accurate when using Float32, especially on a deep MG level with small residuals, so you can end up adding noise instead of making progress. 

A _good_ solution would be to improve the inner product function. That's not trivial, but it would be a good thing to look into. 

What I've done instead is stabilize the solver a little by checking if the preconditioned residual `r'*D^{-1}*r` is increasing instead of decreasing (as it should). This is a good indication that somethings going wrong, and you should stop working at this level. I've set a tolerance of 10% increase for GMG smoothing, and 100% for pure PCG solving. 

I also created an extra parameter `ml.maxlevels` to limit the number of levels in a Vcycle, avoiding recreating levels when incrementing down. 