### PR TITLE
Use fast `measure(body)` in `measure!(flow)`

### DIFF
--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -82,7 +82,7 @@ end
 BDIM-masked surface normal.
 """
 @inline function nds(body,x,t)
-    d,n,_ = measure(body,x,t,fast=true)
+    d,n,_ = measure(body,x,t,fastd²=1)
     n*WaterLily.kern(clamp(d,-1,1))
 end
 

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -223,6 +223,10 @@ end
         I = CartesianIndex(2,3)
         @test GPUArrays.@allowscalar p[I]≈body1.sdf(loc(0,I,eltype(p)),0.0)
     end
+
+    # check fast version
+    @test all(measure(body1,[3.,4.],0.,fastd²=9) .≈ measure(body1,[3.,4.],0.))
+    @test all(measure(body1,[3.,4.],0.,fastd²=8) .≈ (sdf(body1,[3.,4.],0.,fastd²=9),zeros(2),zeros(2)))
 end
 
 function TGVsim(mem;perdir=(1,2),Re=1e8,T=typeof(Re))


### PR DESCRIPTION
We don't need normal or velocity measurements outside a very narrow band in the solver, so `measure(fast)` can be applied there as well, but the band is variable. Changed `fast=false` to `fastd²=Inf` and n,V are skipped when `d^2>fastd²`. 

Applied in `measure!(flow)` and tests passing, but I haven't benchmarked yet. Should be a bit faster for the Jelly and will _really_ speed up ParametricBody simulations.