### PR TITLE
Add a button to view examples in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WaterLily.jl
 
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://WaterLily-jl.github.io/WaterLily.jl/dev/)
+[![Examples](https://img.shields.io/badge/view-examples-blue.svg)](https://github.com/WaterLily-jl/WaterLily-Examples/)
 [![CI](https://github.com/WaterLily-jl/WaterLily.jl/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/WaterLily-jl/WaterLily.jl/actions)
 [![codecov](https://codecov.io/gh/WaterLily-jl/WaterLily.jl/branch/master/graph/badge.svg?token=8XYFWKOUFN)](https://codecov.io/gh/WaterLily-jl/WaterLily.jl)
 


### PR DESCRIPTION
The example repo is pretty easy to miss otherwise.  This is just a shields.io button, so it's pretty easy to configure!