### PR TITLE
Support OpenCL.jl with POCL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -24,6 +25,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 [extensions]
 WaterLilyAMDGPUExt = "AMDGPU"
 WaterLilyCUDAExt = "CUDA"
+WaterLilyOpenCLExt = "OpenCL"
 WaterLilyReadVTKExt = "ReadVTK"
 WaterLilyWriteVTKExt = "WriteVTK"
 
@@ -45,12 +47,14 @@ GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Makie = "537997a7-5e4e-5d89-9595-2241ea00577e"
+OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 PerformanceTestTools = "dc46b164-d16f-48ec-a853-60448fc869fe"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ReadVTK = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"
 
 [targets]
-test = ["Test", "BenchmarkTools", "CUDA", "AMDGPU", "GPUArrays", "WriteVTK", "ReadVTK"]
+test = ["Test", "BenchmarkTools", "GPUArrays", "WriteVTK", "ReadVTK", "OpenCL", "pocl_jll"]

--- a/ext/WaterLilyOpenCLExt.jl
+++ b/ext/WaterLilyOpenCLExt.jl
@@ -1,0 +1,19 @@
+module WaterLilyOpenCLExt
+
+if isdefined(Base, :get_extension)
+    using OpenCL
+else
+    using ..OpenCL
+end
+
+using WaterLily
+import WaterLily: L₂
+
+"""
+    L₂(a)
+
+L₂ norm of OpenCL array `a` excluding ghosts.
+"""
+L₂(a::CLArray,R::CartesianIndices=inside(a)) = mapreduce(abs2,+,@inbounds(a[R]))
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,14 @@ _cuda = check_compiler("nvcc","release")
 _rocm = check_compiler("hipcc","version")
 _cuda && using CUDA
 _rocm && using AMDGPU
+using pocl_jll
+using OpenCL
+
 function setup_backends()
     arrays = [Array]
     _cuda && CUDA.functional() && push!(arrays, CUDA.CuArray)
     _rocm && AMDGPU.functional() && push!(arrays, AMDGPU.ROCArray)
+    push!(arrays, OpenCL.CLArray)
     return arrays
 end
 


### PR DESCRIPTION
We are currently evaluating switching to POCL for CPU support in KernelAbstractions,
so this PR adds minimal support for that upcoming backend.

For now we will have a version where we have KA old CPU backend and the OpenCL backend to evaluate and fix issues, but the long-term plan is to remove the KA CPU backend.
