### PR TITLE
Removed scalar indexing asserts on GPU extensions

### DIFF
--- a/ext/WaterLilyAMDGPUExt.jl
+++ b/ext/WaterLilyAMDGPUExt.jl
@@ -16,8 +16,6 @@ Asserts AMDGPU is functional when loading this extension.
 """
 __init__() = @assert AMDGPU.functional()
 
-AMDGPU.allowscalar(false) # disallow scalar operations on GPU
-
 """
     L₂(a)
 

--- a/ext/WaterLilyCUDAExt.jl
+++ b/ext/WaterLilyCUDAExt.jl
@@ -16,8 +16,6 @@ Asserts CUDA is functional when loading this extension.
 """
 __init__() = @assert CUDA.functional()
 
-CUDA.allowscalar(false) # disallow scalar operations on GPU
-
 """
     L₂(a)
 


### PR DESCRIPTION
Scalar-indexing asserts on top-level had no impact and they are already the default option.
Closes https://github.com/WaterLily-jl/WaterLily.jl/issues/167.