### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
There are deprecation warnings like 

> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v1. Please update your workflow to use the latest version of actions/cache to avoid interruptions.

in the CI runs, see https://github.com/WaterLily-jl/WaterLily.jl/actions/runs/12119430283. Dependabot is like CompatHelper for GitHub actions and will create PRs bumping the versions of GitHub actions you are using to help you fix these issues.