### PR TITLE
Added large alpha check

### DIFF
--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -129,9 +129,10 @@ function pcg!(p::Poisson{T};it=6) where T
         perBC!(ϵ,p.perdir)
         @inside z[I] = mult(I,p.L,p.D,ϵ)
         alpha = rho/(z⋅ϵ)
+        (abs(alpha)<1e-2 || abs(alpha)>1e2) && return # alpha should be O(1)
         @loop (x[I] += alpha*ϵ[I];
                r[I] -= alpha*z[I]) over I ∈ inside(x)
-        (i==it || abs(alpha)<1e-2) && return
+        i==it && return
         @inside z[I] = r[I]*p.iD[I]
         rho2 = r⋅z
         abs(rho2)<10eps(T) && return


### PR DESCRIPTION
We've been seeing a string of problems related to weird alpha,beta values in `pcg!`. This is typically because of an unsatisfiable residual being handed to the solver.

The best solution is to find the bad input! But making the solver a little more robust also seems like a good idea. Here, I've put a check that alpha is not to small OR TOO BIG.