### PR TITLE
add kwargs... in Simulation constructor

### DIFF
--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -66,7 +66,7 @@ mutable struct Simulation <: AbstractSimulation
     function Simulation(dims::NTuple{N}, u_BC, L::Number;
                         Δt=0.25, ν=0., g=nothing, U=nothing, ϵ=1, perdir=(),
                         uλ=nothing, exitBC=false, body::AbstractBody=NoBody(),
-                        T=Float32, mem=Array) where N
+                        T=Float32, mem=Array, kwargs...) where N
         @assert !(isa(u_BC,Function) && isa(uλ,Function)) "`u_BC` and `uλ` cannot be both specified as Function"
         @assert !(isnothing(U) && isa(u_BC,Function)) "`U` must be specified if `u_BC` is a Function"
         isa(u_BC,Function) && @assert all(typeof.(ntuple(i->u_BC(i,zero(T)),N)).==T) "`u_BC` is not type stable"


### PR DESCRIPTION
This adds some `kwargs...` into the `Simulation` constructor.

This is required for other instances of `AbstractSimulations` that pass a list of `kwargs` to the new structure's constructor, but part of those `kwargs` are not used by `Simulation`, which would result in a `Simulation(...) got unsupported keyword arguments` error

Example:
```julia
struct CoupledSimulation <: AbstractSimulation
    sim :: Simulation
    foo :: AbstractInterface
end
function CoupledSimulation(args...; kwargs...)
    # make the sim
    sim  = Simulation(args...; kwargs...)
    # interface
    interface = Interface(; kwargs...)
    # return the new type
    return CoupledSimulation(sim, interface)
end
Base.getproperty(f::CoupledSimulation, s::Symbol) = s in propertynames(f) ? getfield(f, s) : getfield(f.sim, s)
```