### PR TITLE
Fixed Circle in accelerating flow on GPU test

### DIFF
--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -303,12 +303,12 @@ end
 
 @testset "Circle in accelerating flow" begin
     for f ∈ arrays
-        make_accel_circle(radius=32,H=16) = Simulation(radius.*(2H,2H), 
+        make_accel_circle(radius=32,H=16) = Simulation(radius.*(2H,2H),
             (i,t)-> i==1 ? t : zero(t), radius; U=1, mem=f,
             body=AutoBody((x,t)->√sum(abs2,x .-H*radius)-radius))
         sim = make_accel_circle(); sim_step!(sim)
         @test isapprox(WaterLily.pressure_force(sim)/(π*sim.L^2),[-1,0],atol=0.04)
-        @test maximum(sim.flow.u)/sim.flow.u[2,2,1] > 1.91 # ≈ 2U
+        @test GPUArrays.@allowscalar maximum(sim.flow.u)/sim.flow.u[2,2,1] > 1.91 # ≈ 2U
         foreach(i->sim_step!(sim),1:3)
         @test all(sim.pois.n .≤ 2)
         @test !any(isnan.(sim.pois.n))


### PR DESCRIPTION
Missing an `allowscalar` to pass test on GPU.