### PR TITLE
interp for Cartesian Coordinates

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -235,7 +235,7 @@ end
 """
     interp(x::SVector, arr::AbstractArray)
 
-    Linear interpolation from array `arr` at iCartesian-coordinate `x`.
+    Linear interpolation from array `arr` at Cartesian-coordinate `x`.
     Note: This routine works for any number of dimensions.
 """
 function interp(x::SVector{D}, arr::AbstractArray{T,D}) where {D,T}

--- a/src/util.jl
+++ b/src/util.jl
@@ -235,12 +235,12 @@ end
 """
     interp(x::SVector, arr::AbstractArray)
 
-    Linear interpolation from array `arr` at index-coordinate `x`.
+    Linear interpolation from array `arr` at iCartesian-coordinate `x`.
     Note: This routine works for any number of dimensions.
 """
 function interp(x::SVector{D}, arr::AbstractArray{T,D}) where {D,T}
     # Index below the interpolation coordinate and the difference
-    i = floor.(Int,x); y = x.-i
+    x = x .+ 1.5f0; i = floor.(Int,x); y = x.-i
 
     # CartesianIndices around x
     I = CartesianIndex(i...); R = I:I+oneunit(I)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -81,8 +81,8 @@ using ReadVTK, WriteVTK
         @test GPUArrays.@allowscalar all(u[:,:,1,3] .≈ tan(-1π/16)) && all(u[:,:,2,3] .≈ tan(0)) && all(u[:,:,end,3].-tan(6π/16).<1e-6)
 
         # test interpolation
-        a = zeros(5,5,2) |> f; b = zeros(5,5) |> f
-        apply!((i,x)->x[i]+1.5,a); apply!(x->x[1]+1.5,b) # offset for start of grid
+        a = zeros(8,8,2) |> f; b = zeros(8,8) |> f
+        apply!((i,x)->x[i],a); apply!(x->x[1],b) # offset for start of grid
         @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(2.5,1),a) .≈ [2.5,1.])
         @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(3.5,3),a) .≈ [3.5,3.])
         @test GPUArrays.@allowscalar WaterLily.interp(SVector(2.5,1),b) ≈ 2.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using StaticArrays
 
 check_compiler(compiler,parse_str) = try occursin(parse_str, read(`$compiler --version`, String)) catch _ false end
-_cuda = check_compiler("nvcc","release")
+_cuda = true #check_compiler("nvcc","release")
 _rocm = check_compiler("hipcc","version")
 _cuda && using CUDA
 _rocm && using AMDGPU

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using StaticArrays
 
 check_compiler(compiler,parse_str) = try occursin(parse_str, read(`$compiler --version`, String)) catch _ false end
-_cuda = true #check_compiler("nvcc","release")
+_cuda = check_compiler("nvcc","release")
 _rocm = check_compiler("hipcc","version")
 _cuda && using CUDA
 _rocm && using AMDGPU


### PR DESCRIPTION
This fixes the `interp(x::SVector, A::AbstractArray)` to work with Cartesian coordinates for `x` and not index coordinates.