### PR TITLE
type error in interp

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -265,8 +265,8 @@ end
 function interp(x::SVector{D,T}, arr::AbstractArray{T,D}) where {D,T}
     # Index below the interpolation coordinate and the difference
     x = x .+ 1.5f0; i = floor.(Int,x); y = x.-i
-    
-    # CartesianIndices around x 
+
+    # CartesianIndices around x
     I = CartesianIndex(i...); R = I:I+oneunit(I)
 
     # Linearly weighted sum over arr[R] (in serial)

--- a/src/util.jl
+++ b/src/util.jl
@@ -238,11 +238,11 @@ end
     Linear interpolation from array `arr` at Cartesian-coordinate `x`.
     Note: This routine works for any number of dimensions.
 """
-function interp(x::SVector{D}, arr::AbstractArray{T,D}) where {D,T}
+function interp(x::SVector{D,T}, arr::AbstractArray{T,D}) where {D,T}
     # Index below the interpolation coordinate and the difference
     x = x .+ 1.5f0; i = floor.(Int,x); y = x.-i
-
-    # CartesianIndices around x
+    
+    # CartesianIndices around x 
     I = CartesianIndex(i...); R = I:I+oneunit(I)
 
     # Linearly weighted sum over arr[R] (in serial)
@@ -254,10 +254,10 @@ function interp(x::SVector{D}, arr::AbstractArray{T,D}) where {D,T}
     return s
 end
 using EllipsisNotation
-function interp(x::SVector{D}, varr::AbstractArray) where {D}
+function interp(x::SVector{D,T}, varr::AbstractArray{T}) where {D,T}
     # Shift to align with each staggered grid component and interpolate
-    @inline shift(i) = SVector{D}(ifelse(i==j,0.5,0.0) for j in 1:D)
-    return SVector{D}(interp(x+shift(i),@view(varr[..,i])) for i in 1:D)
+    @inline shift(i) = SVector{D,T}(ifelse(i==j,0.5,0.) for j in 1:D)
+    return SVector{D,T}(interp(x+shift(i),@view(varr[..,i])) for i in 1:D)
 end
 
 check_fn(f,N,T,nargs) = nothing

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -83,13 +83,17 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
         @test GPUArrays.@allowscalar all(u[:,1,:,2] .≈ sin(-1π/4))  && all(u[:,2,:,2] .≈ sin(0)) && all(u[:,end,:,2] .≈ sin(6π/4))
         @test GPUArrays.@allowscalar all(u[:,:,1,3] .≈ tan(-1π/16)) && all(u[:,:,2,3] .≈ tan(0)) && all(u[:,:,end,3].-tan(6π/16).<1e-6)
 
-        # test interpolation
-        a = zeros(8,8,2) |> f; b = zeros(8,8) |> f
-        apply!((i,x)->x[i],a); apply!(x->x[1],b) # offset for start of grid
-        @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(2.5,1),a) .≈ [2.5,1.])
-        @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(3.5,3),a) .≈ [3.5,3.])
-        @test GPUArrays.@allowscalar WaterLily.interp(SVector(2.5,1),b) ≈ 2.5
-        @test GPUArrays.@allowscalar WaterLily.interp(SVector(3.5,3),b) ≈ 3.5
+       # test interpolation, test on two different array type
+       a = zeros(Float32,8,8,2) |> f; b = zeros(Float64,8,8) |> f
+       apply!((i,x)->x[i],a); apply!(x->x[1],b) # offset for start of grid
+       @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(2.5f0,1.f0),a) .≈ [2.5f0,1.0f0])
+       @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(3.5f0,3.f0),a) .≈ [3.5f0,3.0f0])
+       @test GPUArrays.@allowscalar eltype(WaterLily.interp(SVector(2.5f0,1.f0),a))==Float32
+       @test_throws MethodError GPUArrays.@allowscalar WaterLily.interp(SVector(2.50,1.0),a)
+       @test GPUArrays.@allowscalar WaterLily.interp(SVector(2.5,1),b) ≈ 2.5
+       @test GPUArrays.@allowscalar WaterLily.interp(SVector(3.5,3),b) ≈ 3.5
+       @test GPUArrays.@allowscalar eltype(WaterLily.interp(SVector(3.5,3),b))==Float64
+       @test_throws MethodError GPUArrays.@allowscalar WaterLily.interp(SVector(2.5f0,1.f0),b)
     end
 end
 


### PR DESCRIPTION
The `interp` function still had an issue, which was dispatching to `Float64` by default when operating on vector arrays this was only breaking on GPUs; this was missed by the test. I'll try to determine the reason and add a test for this before we merge.

This is not the identical function that we have in `Pathlines.jl`.