### PR TITLE
CI now only triggered by PR or pushes on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,22 @@
 name: CI
 on:
   pull_request:
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'ext/**'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
   push:
+    branches:
+      - master
+    tags: '*'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'ext/**'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
 jobs:
   test:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Also, only triggered when changes are detected on certain `paths`. I have implemented this base on the CI of[ Oceananigans.jl](https://github.com/CliMA/Oceananigans.jl/blob/main/.github/workflows/ci.yml) and [Trixi.jl](https://github.com/trixi-framework/Trixi.jl/blob/main/.github/workflows/ci.yml), which follow this same logic.