### PR TITLE
New SetBody struct

### DIFF
--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -22,7 +22,7 @@ end
 """
     d = sdf(body::AutoBody,x,t) = body.sdf(x,t)
 """
-sdf(body::AutoBody,x,t;kwargs...) = body.sdf(x,t)
+sdf(body::AutoBody,x,t=0;kwargs...) = body.sdf(x,t)
 
 using ForwardDiff
 """

--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -19,104 +19,25 @@ struct AutoBody{F1<:Function,F2<:Function} <: AbstractBody
     end
 end
 
-function Base.:+(a::AutoBody, b::AutoBody)
-    map(x,t) = ifelse(a.sdf(x,t)<b.sdf(x,t),a.map(x,t),b.map(x,t))
-    sdf(x,t) = min(a.sdf(x,t),b.sdf(x,t))
-    AutoBody(sdf,map,compose=false)
-end
-function Base.:∩(a::AutoBody, b::AutoBody)
-    map(x,t) = ifelse(a.sdf(x,t)>b.sdf(x,t),a.map(x,t),b.map(x,t))
-    sdf(x,t) = max(a.sdf(x,t),b.sdf(x,t))
-    AutoBody(sdf,map,compose=false)
-end
-Base.:∪(x::AutoBody, y::AutoBody) = x+y
-Base.:-(x::AutoBody) = AutoBody((d,t)->-x.sdf(d,t),x.map,compose=false)
-Base.:-(x::AutoBody, y::AutoBody) = x ∩ -y
-
 """
     d = sdf(body::AutoBody,x,t) = body.sdf(x,t)
 """
 sdf(body::AutoBody,x,t;kwargs...) = body.sdf(x,t)
 
-"""
-    Bodies(bodies, ops::AbstractVector)
-
-  - `bodies::Vector{AutoBody}`: Vector of `AutoBody`
-  - `ops::Vector{Function}`: Vector of operators for the superposition of multiple `AutoBody`s
-
-Superposes multiple `body::AutoBody` objects together according to the operators `ops`.
-While this can be manually performed by the operators implemented for `AutoBody`, adding too many
-bodies can yield a recursion problem of the `sdf` and `map` functions not fitting in the stack.
-This type implements the superposition of bodies by iteration instead of recursion, and the reduction of the `sdf` and `map`
-functions is done on the `mesure` function, and not before.
-The operators vector `ops` specifies the operation to call between two consecutive `AutoBody`s in the `bodies` vector.
-Note that `+` (or the alias `∪`) is the only operation supported between `Bodies`.
-"""
-struct Bodies <: AbstractBody
-    bodies::Vector{AutoBody}
-    ops::Vector{Function}
-    function Bodies(bodies, ops::AbstractVector)
-        all(x -> x==Base.:+ || x==Base.:- || x==Base.:∩ || x==Base.:∪, ops) &&
-            ArgumentError("Operations array `ops` not supported. Use only `ops ∈ [+,-,∩,∪]`")
-        length(bodies) != length(ops)+1 && ArgumentError("length(bodies) != length(ops)+1")
-        new(bodies,ops)
-    end
-end
-Bodies(bodies) = Bodies(bodies,repeat([+],length(bodies)-1))
-Bodies(bodies, op::Function) = Bodies(bodies,repeat([op],length(bodies)-1))
-Base.:+(a::Bodies, b::Bodies) = Bodies(vcat(a.bodies, b.bodies), vcat(a.ops, b.ops))
-Base.:∪(a::Bodies, b::Bodies) = a+b
-
-"""
-    sdf_map_d(ab::Bodies,x,t)
-
-Returns the `sdf` and `map` functions, and the distance `d` (`d=sdf(x,t)`) for the `Bodies` type.
-"""
-function sdf_map_d(bodies,ops,x,t)
-    sdf, map, d = bodies[1].sdf, bodies[1].map, bodies[1].sdf(x,t)
-    for i ∈ eachindex(bodies)[begin+1:end]
-        sdf2, map2, d2 = bodies[i].sdf, bodies[i].map, bodies[i].sdf(x,t)
-        sdf, map, d = reduce_sdf_map(sdf,map,d,sdf2,map2,d2,ops[i-1])
-    end
-    return sdf, map, d
-end
-"""
-    reduce_sdf_map(sdf_a,map_a,d_a,sdf_b,map_b,d_b,op,x,t)
-
-Reduces two different `sdf` and `map` functions, and `d` value.
-"""
-function reduce_sdf_map(sdf_a,map_a,d_a,sdf_b,map_b,d_b,op)
-    (Base.:+ == op || Base.:∪ == op) && d_b < d_a && return (sdf_b, map_b, d_b)
-    Base.:- == op && -d_b > d_a && return ((y,u)->-sdf_b(y,u), map_b, -d_b)
-    Base.:∩ == op && d_b > d_a && return (sdf_b, map_b, d_b)
-    return sdf_a, map_a, d_a
-end
-"""
-    d = sdf(a::Bodies,x,t)
-
-Computes distance for `Bodies` type.
-"""
-sdf(a::Bodies,x,t;kwargs...) = sdf_map_d(a.bodies,a.ops,x,t)[end]
-
 using ForwardDiff
 """
-    d,n,V = measure(body::AutoBody||Bodies,x,t;fastd²=Inf)
+    d,n,V = measure(body::AutoBody,x,t;fastd²=Inf)
 
 Determine the implicit geometric properties from the `sdf` and `map`.
 The gradient of `d=sdf(map(x,t))` is used to improve `d` for pseudo-sdfs.
 The velocity is determined _solely_ from the optional `map` function.
 Skips the `n,V` calculation when `d²>fastd²`.
 """
-measure(body::AutoBody,x,t;kwargs...) = measure(body.sdf,body.map,x,t;kwargs...)
-function measure(a::Bodies,x,t;kwargs...)
-    sdf, map, _ = sdf_map_d(a.bodies,a.ops,x,t)
-    measure(sdf,map,x,t;kwargs...)
-end
-function measure(sdf,map,x,t;fastd²=Inf)
+function measure(body::AutoBody,x,t;fastd²=Inf)
     # eval d=f(x,t), and n̂ = ∇f
-    d = sdf(x,t)
+    d = body.sdf(x,t)
     d^2>fastd² && return (d,zero(x),zero(x)) # skip n,V
-    n = ForwardDiff.gradient(x->sdf(x,t), x)
+    n = ForwardDiff.gradient(x->body.sdf(x,t), x)
     any(isnan.(n)) && return (d,zero(x),zero(x))
 
     # correct general implicit fnc f(x₀)=0 to be a pseudo-sdf
@@ -125,8 +46,8 @@ function measure(sdf,map,x,t;fastd²=Inf)
 
     # The velocity depends on the material change of ξ=m(x,t):
     #   Dm/Dt=0 → ṁ + (dm/dx)ẋ = 0 ∴  ẋ =-(dm/dx)\ṁ
-    J = ForwardDiff.jacobian(x->map(x,t), x)
-    dot = ForwardDiff.derivative(t->map(x,t), t)
+    J = ForwardDiff.jacobian(x->body.map(x,t), x)
+    dot = ForwardDiff.derivative(t->body.map(x,t), t)
     return (d,n,-J\dot)
 end
 

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -100,7 +100,6 @@ Base.:-(a::AbstractBody, b::AbstractBody) = a ∩ (-b)
 
 # Measurements
 function measure(body::SetBody,x,t;fastd²=Inf)
-    a,b = map(bod->measure(bod,x,t;fastd²),(body.a,body.b))
-    a==b ? a : body.op(a,b) # required on GPU for some reason!?!
+    body.op(measure(body.a,x,t;fastd²),measure(body.b,x,t;fastd²)) # can't mapreduce within GPU kernel
 end
 measure(body::SetBody{typeof(-)},x,t;fastd²=Inf) = ((d,n,V) = measure(body.a,x,t;fastd²); (-d,-n,V))

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -99,5 +99,8 @@ Base.:-(a::AbstractBody) = SetBody(-,a,NoBody())
 Base.:-(a::AbstractBody, b::AbstractBody) = a ∩ (-b)
 
 # Measurements
-measure(body::SetBody,x,t;fastd²=Inf) = mapreduce(bod->measure(bod,x,t;fastd²),body.op,(body.a,body.b))
+function measure(body::SetBody,x,t;fastd²=Inf)
+    a,b = map(bod->measure(bod,x,t;fastd²),(body.a,body.b))
+    a==b ? a : body.op(a,b) # required on GPU for some reason!?!
+end
 measure(body::SetBody{typeof(-)},x,t;fastd²=Inf) = ((d,n,V) = measure(body.a,x,t;fastd²); (-d,-n,V))

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -61,14 +61,14 @@ end
 
 Measure only the distance. Defaults to fastd²=0 for quick evaluation.
 """
-sdf(body::AbstractBody,x,t=0;fastd²=0,kwargs...) = measure(body,x,t;fastd²)[1]
+sdf(body::AbstractBody,x,t=0;fastd²=0) = measure(body,x,t;fastd²)[1]
 
 """
-    measure_sdf!(a::AbstractArray, body::AbstractBody, t=0)
+    measure_sdf!(a::AbstractArray, body::AbstractBody, t=0; fastd²=0)
 
-Uses `sdf(body,x,t)` to fill `a`.
+Uses `sdf(body,x,t)` to fill `a`. Defaults to fastd²=0 for quick evaluation.
 """
-measure_sdf!(a::AbstractArray,body::AbstractBody,t=0;kwargs...) = @inside a[I] = sdf(body,loc(0,I,eltype(a)),t;kwargs...)
+measure_sdf!(a::AbstractArray{T},body::AbstractBody,t=zero(T);fastd²=zero(T)) where T = @inside a[I] = sdf(body,loc(0,I,T),t;fastd²)::T
 
 """
     NoBody
@@ -93,10 +93,10 @@ end
 
 # Lazy constructors
 Base.:∪(a::AbstractBody, b::AbstractBody) = SetBody(min,a,b)
-Base.:+(a::AbstractBody, b::AbstractBody) = a∪b
+Base.:+(a::AbstractBody, b::AbstractBody) = a ∪ b
 Base.:∩(a::AbstractBody, b::AbstractBody) = SetBody(max,a,b)
 Base.:-(a::AbstractBody) = SetBody(-,a,NoBody())
-Base.:-(a::AbstractBody, b::AbstractBody) = a∩(-b)
+Base.:-(a::AbstractBody, b::AbstractBody) = a ∩ (-b)
 
 # Measurements
 measure(body::SetBody,x,t;fastd²=Inf) = mapreduce(bod->measure(bod,x,t;fastd²),body.op,(body.a,body.b))

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -233,12 +233,12 @@ end
 end
 
 @testset "AutoBody.jl" begin
-    norm2(x) = √sum(abs2,x)
     # test AutoDiff in 2D and 3D
-    body1 = AutoBody((x,t)->norm2(x)-2-t)
+    circ(x,t)=√sum(abs2,x)-2
+    body1 = AutoBody((x,t)->circ(x,t)-t)
+    body2 = AutoBody(circ,(x,t)->x.+t^2)
     @test all(measure(body1,[√2.,√2.],0.).≈(0,[√.5,√.5],[0.,0.]))
     @test all(measure(body1,[2.,0.,0.],1.).≈(-1.,[1.,0.,0.],[0.,0.,0.]))
-    body2 = AutoBody((x,t)->norm2(x)-2,(x,t)->x.+t^2)
     @test all(measure(body2,[√2.,√2.],0.).≈(0,[√.5,√.5],[0.,0.]))
     @test all(measure(body2,[1.,-1.,-1.],1.).≈(0.,[1.,0.,0.],[-2.,-2.,-2.]))
 
@@ -247,16 +247,12 @@ end
     @test all(measure(body1∪body2,[-√2.,-√2.],1.).≈(-√2.,[-√.5,-√.5],[-2.,-2.]))
     @test all(measure(body1-body2,[-√2.,-√2.],1.).≈(√2.,[√.5,√.5],[-2.,-2.]))
 
-    # tests for Bodies
-    @test all(measure(Bodies([body1,body2]),[-√2.,-√2.],1.).≈measure(body1+body2,[-√2.,-√2.],1.))
-    @test all(measure(Bodies([body1,body2],-),[-√2.,-√2.],1.).≈measure(body1-body2,[-√2.,-√2.],1.))
-
-    radius = [1.0, 0.75, 0.5, 0.25]
-    circles = [(x,t) -> √sum(abs2,x)-r for r ∈ radius]
-    body = AutoBody(circles[1])-AutoBody(circles[2])+AutoBody(circles[3])-AutoBody(circles[4])
-    bodies = Bodies(AutoBody[AutoBody(c) for c ∈ circles], [-,+,-])
-    xy = rand(2)
-    @test all(measure(body, xy, 1.).≈measure(bodies, xy, 1.))
+    # test scaling
+    body = AutoBody(circ)
+    for i in 2:20
+        body += AutoBody(circ,(x,t)->x-rand(2))
+        @test sizeof(body) == i
+    end
 
     # test curvature, 2D and 3D
     # A = ForwardDiff.Hessian(y->body1.sdf(y,0.0),[0.,0.])

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -265,11 +265,12 @@ end
     @test all(WaterLily.curvature([1. 0.; 0. 1.]).≈(1.,0.))
     @test all(WaterLily.curvature([2. 1. 0.; 1. 2. 1.; 0. 1. 2.]).≈(3.,10.))
 
-    # check that sdf functions are the same
+    # check sdf on arrays and that it recovers set arithmetic identity
     for f ∈ arrays
-        p = zeros(4,5) |> f; measure_sdf!(p,body1)
-        I = CartesianIndex(2,3)
-        @test GPUArrays.@allowscalar p[I]≈body1.sdf(loc(0,I,eltype(p)),0.0)
+        p = zeros(Float32,4,5) |> f; measure_sdf!(p,(body1 ∩ body2) ∪ body1)
+        for I ∈ inside(p)
+            @test GPUArrays.@allowscalar p[I]≈sdf(body1,loc(0,I,Float32))
+        end
     end
 
     # check fast version

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -230,6 +230,9 @@ end
     @test WaterLily.μ₀(3,6)==WaterLily.μ₀(0.5,1)
     @test WaterLily.μ₀(0,1)==0.5
     @test WaterLily.μ₁(0,2)==2*(1/4-1/π^2)
+
+    @test all(measure(WaterLily.NoBody(),[2,1],0) .== (Inf,zeros(2),zeros(2)))
+    @test sdf(WaterLily.NoBody(),[2,1],0) == Inf
 end
 
 @testset "AutoBody.jl" begin
@@ -246,6 +249,9 @@ end
     @test all(measure(body1+body2,[-√2.,-√2.],1.).≈(-√2.,[-√.5,-√.5],[-2.,-2.]))
     @test all(measure(body1∪body2,[-√2.,-√2.],1.).≈(-√2.,[-√.5,-√.5],[-2.,-2.]))
     @test all(measure(body1-body2,[-√2.,-√2.],1.).≈(√2.,[√.5,√.5],[-2.,-2.]))
+
+    # test sdf and exactly equal distance bodies
+    @test sdf(AutoBody(circ)+AutoBody(circ,(x,t)->x.-[6,0]),[3.,0.],0.) == 1
 
     # test scaling
     body = AutoBody(circ)


### PR DESCRIPTION
Lazy construction of set operations on AbstractBodies. Combining the best of the old boolean operators (easy to use and work on GPUs) and Bodies struct (lazy construction means no memory blow up). Also applies to any AbstractBody, not just AutoBody. And all in 11 lines of code...

This PR also fixes a few inconsistencies in the AbstractBody interface. It supplies a default `sdf` function so extended type only have to supply `measure`. Of course, you can specialize on `sdf` if it would be helpful (like for AutoBodies). And NoBody was missing `measure` which would have thrown an error if people tried to `measure_sdf` of a default simulation. Now it gives d=Inf, which should be compatible with any other bodies.

I _might_ also modify the `measure!(::Flow)` function so we can create `SharpBody` with a sharp trailing edge. But maybe that should be a seperate PR. 