### PR TITLE
Added automatic colormap for visualization in Makie with `tidy_colormap` keyword argument

### DIFF
--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -167,9 +167,8 @@ export flood,addbody,body_plot!,sim_gif!,plot_logger
 function viz! end
 function get_body end
 function plot_body_obs! end
-function ω_viz! end
 # export
-export viz!, get_body, plot_body_obs!, ω_viz!
+export viz!, get_body, plot_body_obs!
 
 # Check number of threads when loading WaterLily
 """

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -167,8 +167,9 @@ export flood,addbody,body_plot!,sim_gif!,plot_logger
 function viz! end
 function get_body end
 function plot_body_obs! end
+function ω_viz! end
 # export
-export viz!, get_body, plot_body_obs!
+export viz!, get_body, plot_body_obs!, ω_viz!
 
 # Check number of threads when loading WaterLily
 """


### PR DESCRIPTION
Added automatic colormap for visualization in Makie with `tidy_colormap` keyword argument. Also made `f` plotting function a keyword argument, instead of a positional argument. By default, now the 2D/3D vorticity is plotted.