### PR TITLE
Removed `meanflow` kwarg from `simstep!`, and other minor fixes in `MeanFlow`

### DIFF
--- a/ext/WaterLilyJLD2Ext.jl
+++ b/ext/WaterLilyJLD2Ext.jl
@@ -25,7 +25,7 @@ save!(fname, meanflow::MeanFlow; dir="./") = jldsave(
     joinpath(dir, fname);
     P=Array(meanflow.P),
     U=Array(meanflow.U),
-    UU=Array(meanflow.UU),
+    UU=isnothing(meanflow.UU) ? nothing : Array(meanflow.UU),
     t=meanflow.t
 )
 
@@ -64,6 +64,7 @@ function load!(meanflow::MeanFlow; kwargs...)
     f = typeof(meanflow.P).name.wrapper
     meanflow.P .= obj["P"] |> f
     meanflow.U .= obj["U"] |> f
+    isnothing(meanflow.UU) || (meanflow.UU .= obj["UU"] |> f)
     empty!(meanflow.t)
     push!(meanflow.t, obj["t"]...)
     close(obj)

--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -135,7 +135,7 @@ Keyword arguments:
     - `fig_pad::Int`: Figure padding.
     - `kwargs`: Additional keyword arguments passed to `plot_σ_obs!`.
 """
-function viz!(sim; f=ω_viz!(ndims(sim.flow.p)), duration=nothing, step=0.1, remeasure=true, verbose=true,
+function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbose=true,
     λ=quick, udf=nothing, udf_kwargs=nothing, meanflow=nothing,
     d=ndims(sim.flow.p), CIs=nothing, cut=nothing, tidy_colormap=true,
     body=!(typeof(sim.body)<:WaterLily.NoBody), body_color=:grey, body2mesh=false,
@@ -162,6 +162,7 @@ function viz!(sim; f=ω_viz!(ndims(sim.flow.p)), duration=nothing, step=0.1, rem
     @assert d <= D "Cannot do a 3D plot on a 2D simulation."
     !isnothing(udf) && !isnothing(udf_kwargs) && (@assert all(isa(kw, Pair{Symbol}) for kw in udf_kwargs) "udf_kwargs needs to contain Pair{Symbol,Any} elements, eg. Dict{Symbol,Any}.")
     isnothing(udf) && (udf_kwargs=[])
+    isnothing(f) && (f = ω_viz!(d))
 
     isnothing(CIs) && (CIs = CartesianIndices(Tuple(1:n for n in size(inside(sim.flow.σ)))))
     dat = sim.flow.σ[inside(sim.flow.σ)] |> Array

--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -82,7 +82,7 @@ plot_σ_obs!(ax, σ::Observable{Array{T,3}} where T; kwargs...) = Makie.volume!(
 
 """
     viz!(sim; f=ω_viz!(ndims(sim.flow.p)), duration=nothing, step=0.1, remeasure=true, verbose=true,
-        λ=quick, udf=nothing, udf_kwargs=nothing, meanflow=nothing,
+        λ=quick, udf=nothing, udf_kwargs=nothing,
         d=ndims(sim.flow.p), CIs=nothing, cut=nothing, tidy_colormap=true,
         body=!(typeof(sim.body)<:WaterLily.NoBody), body_color=:grey, body2mesh=false,
         video=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
@@ -107,7 +107,6 @@ Keyword arguments:
     - `remeasure::Bool`: Update the body position.
     - `verbose::Bool`: Print simulation information.
     - `λ::Function`: Convective scheme function passed into `sim_step!`.
-    - `meanflow::MeanFlow`: `MeanFlow` object passed into `sim_step!`.
     - `udf::Function`: User-defined function passed into `sim_step!`.
     - `udf_kwargs::Dict{Symbol}`: User-defined function keyword arguments passed into `sim_step!`. Needs to be a `Dict{Symbol}` or any
         `Pair{Symbol,Any}` iterator.
@@ -136,7 +135,7 @@ Keyword arguments:
     - `kwargs`: Additional keyword arguments passed to `plot_σ_obs!`.
 """
 function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbose=true,
-    λ=quick, udf=nothing, udf_kwargs=nothing, meanflow=nothing,
+    λ=quick, udf=nothing, udf_kwargs=nothing,
     d=ndims(sim.flow.p), CIs=nothing, cut=nothing, tidy_colormap=true,
     body=!(typeof(sim.body)<:WaterLily.NoBody), body_color=:grey, body2mesh=false,
     video=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
@@ -151,7 +150,7 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
         end
     end
     function step_sim_and_viz!(sim, tᵢ)
-        sim_step!(sim, tᵢ; remeasure, λ, udf, meanflow, udf_kwargs...)
+        sim_step!(sim, tᵢ; remeasure, λ, udf, udf_kwargs...)
         verbose && sim_info(sim)
         update_data()
     end

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -194,10 +194,10 @@ function update!(meanflow::MeanFlow, flow::Flow)
 end
 
 uu!(τ,a::MeanFlow) = for i in 1:ndims(a.P), j in 1:ndims(a.P)
-    @loop τ[I,i,j] = a.UU[I,i,j] - a.U[I,i,j] * a.U[I,i,j] over I in CartesianIndices(a.P)
+    @loop τ[I,i,j] = a.UU[I,i,j] - a.U[I,i] * a.U[I,j] over I in CartesianIndices(a.P)
 end
 function uu(a::MeanFlow)
-    τ = zeros(eltype(a.UU), size(a.UU)...) |> typeof(meanflow.UU).name.wrapper
+    τ = zeros(eltype(a.UU), size(a.UU)...) |> typeof(a.UU).name.wrapper
     uu!(τ,a)
     return τ
 end

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -181,7 +181,8 @@ end
 
 function update!(meanflow::MeanFlow, flow::Flow)
     dt = time(flow) - meanflow.t[end]
-    ε = dt / (dt + (meanflow.t[end] - meanflow.t[1]) + eps(eltype(flow.p)))
+    ε = dt / (dt + time(meanflow) + eps(eltype(flow.p)))
+    length(meanflow.t) == 1 && (ε = 1) # if it's the first update, we just take the instantaneous flow field
     @loop meanflow.P[I] = ε * flow.p[I] + (1 - ε) * meanflow.P[I] over I in CartesianIndices(flow.p)
     @loop meanflow.U[Ii] = ε * flow.u[Ii] + (1 - ε) * meanflow.U[Ii] over Ii in CartesianIndices(flow.u)
     if meanflow.uu_stats

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -90,13 +90,12 @@ sim_time(sim::AbstractSimulation) = time(sim)*sim.U/sim.L
 
 """
     sim_step!(sim::AbstractSimulation,t_end;remeasure=true,λ=quick,max_steps=typemax(Int),verbose=false,
-        udf=nothing,meanflow=nothing,kwargs...)
+        udf=nothing,kwargs...)
 
 Integrate the simulation `sim` up to dimensionless time `t_end`.
 If `remeasure=true`, the body is remeasured at every time step. Can be set to `false` for static geometries to speed up simulation.
 A user-defined function `udf` can be passed to arbitrarily modify the `::Flow` during the predictor and corrector steps.
 If the `udf` user keyword arguments, these needs to be included in the `sim_step!` call as well.
-A `::MeanFlow` can also be passed to compute on-the-fly temporal averages.
 A `λ::Function` function can be passed as a custom convective scheme, following the interface of `λ(u,c,d)` (for upstream, central,
 downstream points).
 """
@@ -111,7 +110,6 @@ end
 function sim_step!(sim::AbstractSimulation;remeasure=true,λ=quick,udf=nothing,kwargs...)
     remeasure && measure!(sim)
     mom_step!(sim.flow, sim.pois; λ, udf, kwargs...)
-    !isnothing(meanflow) && update!(meanflow,sim.flow)
 end
 
 """

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -27,7 +27,7 @@ include("AutoBody.jl")
 export AutoBody,Bodies,measure,sdf,+,-
 
 include("Metrics.jl")
-export MeanFlow
+export MeanFlow,update!,uu!,uu
 
 abstract type AbstractSimulation end
 """
@@ -101,14 +101,14 @@ A `λ::Function` function can be passed as a custom convective scheme, following
 downstream points).
 """
 function sim_step!(sim::AbstractSimulation,t_end;remeasure=true,λ=quick,max_steps=typemax(Int),verbose=false,
-        udf=nothing,meanflow=nothing,kwargs...)
+        udf=nothing,kwargs...)
     steps₀ = length(sim.flow.Δt)
     while sim_time(sim) < t_end && length(sim.flow.Δt) - steps₀ < max_steps
-        sim_step!(sim; remeasure, λ, udf, meanflow, kwargs...)
+        sim_step!(sim; remeasure, λ, udf, kwargs...)
         verbose && sim_info(sim)
     end
 end
-function sim_step!(sim::AbstractSimulation;remeasure=true,λ=quick,udf=nothing,meanflow=nothing,kwargs...)
+function sim_step!(sim::AbstractSimulation;remeasure=true,λ=quick,udf=nothing,kwargs...)
     remeasure && measure!(sim)
     mom_step!(sim.flow, sim.pois; λ, udf, kwargs...)
     !isnothing(meanflow) && update!(meanflow,sim.flow)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -463,7 +463,10 @@ import WaterLily: ×
         T = Float32
         sim = make_bl_flow(; T, mem=f)
         meanflow = MeanFlow(sim.flow; uu_stats=true)
-        sim_step!(sim, 10; meanflow)
+        for t in range(0,10;step=0.1)
+            sim_step!(sim, t)
+            update!(meanflow, sim.flow)
+        end
         @test all(isapprox.(Array(sim.flow.u), Array(meanflow.U); atol=√eps(T))) # can't broadcast isapprox for GPUArrays...
         @test all(isapprox.(Array(sim.flow.p), Array(meanflow.P); atol=√eps(T)))
         for i in 1:ndims(sim.flow.p), j in 1:ndims(sim.flow.p)
@@ -568,7 +571,10 @@ end
         # temporal averages
         sim = make_bl_flow(; T=Float32, mem)
         meanflow1 = MeanFlow(sim.flow; uu_stats=true)
-        sim_step!(sim, 10; meanflow1)
+        for t in range(0,10;step=0.1)
+            sim_step!(sim, t)
+            update!(meanflow1, sim.flow)
+        end
         save!("meanflow.jld2", meanflow1; dir=test_dir)
         meanflow2 = MeanFlow(sim.flow; uu_stats=true)
         WaterLily.reset!(meanflow2)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -472,6 +472,13 @@ import WaterLily: ×
         for i in 1:ndims(sim.flow.p), j in 1:ndims(sim.flow.p)
             @test all(isapprox.(Array(sim.flow.u)[:,:,i] .* Array(sim.flow.u)[:,:,j], Array(meanflow.UU)[:,:,i,j]; atol=√eps(T)))
         end
+        τ = uu(meanflow)
+        for i in 1:ndims(sim.flow.p), j in 1:ndims(sim.flow.p)
+            @test all(isapprox.(
+                Array(meanflow.UU)[:,:,i,j] .- Array(meanflow.U)[:,:,i].*Array(meanflow.U)[:,:,j],
+                Array(τ)[:,:,i,j]; atol=√eps(T))
+            )
+        end
         @test WaterLily.time(sim.flow) == WaterLily.time(meanflow)
         WaterLily.reset!(meanflow)
         @test all(meanflow.U .== zero(T))


### PR DESCRIPTION
Users should now call `update!(meanflow::MeanFlow,flow::Flow)` themselves to update the mean flow and second order statistics. This is motivated by the fact that we do not need to update them at every time step: this can be too expansive and unnecessary from the stats standpoint.