### PR TITLE
Fix `viz!` and `measure_sdf!` functions for `Dual` type simulations

### DIFF
--- a/src/Body.jl
+++ b/src/Body.jl
@@ -68,7 +68,7 @@ sdf(body::AbstractBody,x,t=0;fastd²=0) = measure(body,x,t;fastd²)[1]
 
 Uses `sdf(body,x,t)` to fill `a`. Defaults to fastd²=0 for quick evaluation.
 """
-measure_sdf!(a::AbstractArray{T},body::AbstractBody,t=zero(T);fastd²=zero(T)) where T = @inside a[I] = sdf(body,loc(0,I,T),t;fastd²)::T
+measure_sdf!(a::AbstractArray{T},body::AbstractBody,t=zero(T);fastd²=zero(T)) where T = @inside a[I] = sdf(body,loc(0,I,T),t;fastd²)
 
 """
     NoBody


### PR DESCRIPTION
Also adds `viz!(sim, a::AbstractArray; kwargs...)` to visualize an arbitrary array without passing the `f` kwarg function.