### PR TITLE
Initial commit of a simple GPU-friendly Gauss-Seidel Red-Black smoother

### DIFF
--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -112,6 +112,23 @@ Note: This runs for general backends, but is _very_ slow to converge.
     increment!(p)
 end
 
+"""
+    GaussSeidelRB!(p::Poisson; it=6)
+
+Gauss-Seidel Red-Black smoother run `it` times. 
+Note: This runs for general backends, but the LinearIndices might be slow...
+"""
+function GaussSeidelRB!(p; it=6)
+    gauss(I,x,p,flag) = flag && (x[I] += (p.r[I]-mult(I,p.L,p.D,x))*p.iD[I])
+    Lin = LinearIndices(inside(p.x)) # linear indices for red-black
+    @inside p.ϵ[I] = p.r[I]*p.iD[I]  # initialize ϵ
+    for _ in 1:it
+        @loop gauss(I,p.ϵ,p,Lin[I]%2==0) over I ∈ inside(p.x) # "red"
+        @loop gauss(I,p.ϵ,p,Lin[I]%2==1) over I ∈ inside(p.x) # "black"
+    end
+    increment!(p) # increment solution and residual
+end
+
 using LinearAlgebra: ⋅
 """
     pcg!(p::Poisson; it=6)


### PR DESCRIPTION
This is an initial implementation of a Gauss-Seidel smoother which runs on GPUs by alternating the update in a checkerboard pattern. 

- This smoother has no accumulations, and should be less sensitive than `PCG!` to things like reduced precision. It _might_ improve the AD with respect to body position, but I haven't tested it.
- The Gauss-Seidel kernel is launched on the whole array twice, and LinearIndex[I]%2 is used to alternate between even/odd cells. I'm sure there are better implementations, but we can start with this.
- There are no tolerances or residual checks. This is fast, but might be wasting effort or require more V-cycles.

