### PR TITLE
Reverse AD via Enzyme extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Meshing = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"
@@ -31,6 +32,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 [extensions]
 WaterLilyAMDGPUExt = "AMDGPU"
 WaterLilyCUDAExt = "CUDA"
+WaterLilyEnzymeCoreExt = "EnzymeCore"
 WaterLilyMakieExt = "Makie"
 WaterLilyJLD2Ext = "JLD2"
 WaterLilyMeshingExt = ["Makie", "Meshing"]

--- a/ext/WaterLilyEnzymeCoreExt.jl
+++ b/ext/WaterLilyEnzymeCoreExt.jl
@@ -1,0 +1,60 @@
+module WaterLilyEnzymeCoreExt
+
+using WaterLily
+using EnzymeCore
+using EnzymeCore.EnzymeRules
+
+# Discrete-adjoint rule for the multigrid Poisson solve. Forward solves Ax = z;
+# reverse solves A λ = x̄ with the same multigrid (A is symmetric — face
+# coefficients in L are shared by adjacent cells, and BDIM modulates μ₀ on
+# faces preserving symmetry — so Aᵀ = A) and accumulates cotangents into the
+# source-term and operator-coefficient shadows.
+#
+# The cost passed to autodiff must be invariant to constant pressure shifts
+# (e.g. `sum(u)`, force integrals) — `sum(p)` has uniform cotangents that lie
+# in nullspace(Aᵀ) and produces zero gradient. Tighten Poisson tolerance for
+# accurate gradients (defaults stop at 1e-4; 1e-10 gives ~5 sig figs vs FD).
+
+function EnzymeRules.augmented_primal(
+    config::RevConfigWidth{1},
+    func::Const{typeof(WaterLily.poisson_solve!)},
+    ::Type{<:Const},
+    p::Duplicated{<:WaterLily.MultiLevelPoisson},
+)
+    func.val(p.val)
+    tape = copy(p.val.levels[1].x)
+    return AugmentedReturn{Nothing,Nothing,typeof(tape)}(nothing, nothing, tape)
+end
+
+function EnzymeRules.reverse(
+    config::RevConfigWidth{1},
+    func::Const{typeof(WaterLily.poisson_solve!)},
+    dret,
+    tape,
+    p::Duplicated{<:WaterLily.MultiLevelPoisson},
+)
+    pp, dpp = p.val, p.dval
+    x_saved = tape
+    fine, dfine = pp.levels[1], dpp.levels[1]
+
+    fine.z .= dfine.x
+    fill!(fine.x, 0)
+    func.val(pp)
+    λ = fine.x
+
+    # x = A⁻¹ z, λ = A⁻ᵀ x̄. Accumulate dz̄ += λ; dA_{IJ} += -λ_I x_J.
+    # A[I, I-δᵢ] = L[I, i] (off-diag), A[I, I] = D[I] (diagonal); other entries 0.
+    dfine.z .+= λ
+    d = ndims(x_saved)
+    for i in 1:d
+        WaterLily.@loop dfine.L[I, i] += -(λ[I]*x_saved[I-WaterLily.δ(i,I)] +
+                                           λ[I-WaterLily.δ(i,I)]*x_saved[I]) over I in WaterLily.inside(x_saved)
+    end
+    WaterLily.@loop dfine.D[I] += -λ[I]*x_saved[I] over I in WaterLily.inside(x_saved)
+
+    fine.x .= x_saved
+    fill!(dfine.x, 0)
+    return (nothing,)
+end
+
+end # module

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -131,7 +131,7 @@ end
 function project!(a::Flow{n},b::AbstractPoisson,w=1) where n
     dt = w*a.Δt[end]
     @inside b.z[I] = div(I,a.u); b.x .*= dt # set source term & solution IC
-    solver!(b)
+    poisson_solve!(b)
     for i ∈ 1:n  # apply solution and unscale to recover pressure
         @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)
     end
@@ -147,7 +147,6 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
 @fastmath function mom_step!(a::Flow{N},b::AbstractPoisson;λ=quick,udf=nothing,kwargs...) where N
     a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
     # predictor u → u'
-    @log "p"
     conv_diff!(a.f,a.u⁰,a.σ,λ;ν=a.ν,perdir=a.perdir)
     udf!(a,udf,t₀; kwargs...)
     accelerate!(a.f,t₀,a.g,a.uBC)
@@ -155,7 +154,6 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     a.exitBC && exitBC!(a.u,a.u⁰,a.Δt[end]) # convective exit
     project!(a,b); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     # corrector u → u¹
-    @log "c"
     conv_diff!(a.f,a.u,a.σ,λ;ν=a.ν,perdir=a.perdir)
     udf!(a,udf,t₁; kwargs...)
     accelerate!(a.f,t₁,a.g,a.uBC)

--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -106,3 +106,13 @@ function solver!(ml::MultiLevelPoisson{T};tol=1e-4,itmx=32) where T
     perBC!(p.x,p.perdir)
     push!(ml.n,nᵖ);
 end
+
+"""
+    poisson_solve!(p::AbstractPoisson)
+
+No-kwargs, `nothing`-returning wrapper around `solver!`. Provides a stable
+extension point for AD backends to register a custom Poisson rule on (Enzyme
+dispatches kwargs through `Core.kwcall`, so a rule on `solver!` itself does
+not fire).
+"""
+poisson_solve!(p::AbstractPoisson) = (solver!(p); nothing)

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -15,7 +15,7 @@ include("Poisson.jl")
 export AbstractPoisson,Poisson,solver!,mult!
 
 include("MultiLevelPoisson.jl")
-export MultiLevelPoisson,solver!,mult!
+export MultiLevelPoisson,solver!,mult!,poisson_solve!
 
 include("Flow.jl")
 export Flow,mom_step!,quick,cds

--- a/src/util.jl
+++ b/src/util.jl
@@ -132,20 +132,20 @@ Note that `get_backend` is used on the _first_ variable in `expr` (`a` in this e
 macro loop(args...)
     ex,_,itr = args
     _,I,R = itr.args
-    sym = []
-    grab!(sym,ex)     # get arguments and replace composites in `ex`
-    setdiff!(sym,[I]) # don't want to pass I as an argument
-    symT = [gensym() for _ in 1:length(sym)] # generate a list of types for each symbol
-    symWtypes = joinsymtype(rep.(sym),symT) # symbols with types: [a::A, b::B, ...]
-    @gensym(kern, kern_) # generate unique kernel function names for serial and KA execution
     @static if backend == "KernelAbstractions"
+        sym = []                # data symbols + bare-symbol call heads
+        grab!(sym,ex,true)      # KA needs call heads passed in (kernel is module-scoped)
+        setdiff!(sym,[I])
+        symT = [gensym() for _ in 1:length(sym)]
+        symWtypes = joinsymtype(rep.(sym),symT)
+        @gensym(kern_)
         # Define the @kernel at module scope (not inside the caller's function body):
         # when @kernel is generated inside another function, the resulting kernel
         # functor is a closure-typed object, and Enzyme cannot trace through
         # KernelAbstractions.construct's generic call to build it. Lifting to
         # module scope makes it a stable global functor that Enzyme handles.
         Core.eval(__module__, quote
-            @kernel function $kern_($(symWtypes...),@Const(I0)) where {$(symT...)} # replace composite arguments
+            @kernel function $kern_($(symWtypes...),@Const(I0)) where {$(symT...)}
                 $I = @index(Global,Cartesian)
                 $I += I0
                 @fastmath @inbounds $ex
@@ -155,6 +155,12 @@ macro loop(args...)
             $kern_(get_backend($(sym[1])),64)($(sym...),$R[1]-oneunit($R[1]),ndrange=size($R))
         end |> esc
     else # backend == "SIMD"
+        sym = []
+        grab!(sym,ex,false)     # SIMD doesn't need call heads; they resolve via lexical scope
+        setdiff!(sym,[I])
+        symT = [gensym() for _ in 1:length(sym)]
+        symWtypes = joinsymtype(rep.(sym),symT)
+        @gensym(kern)
         return quote
             function $kern($(symWtypes...)) where {$(symT...)}
                 @simd for $I ∈ $R
@@ -165,28 +171,27 @@ macro loop(args...)
         end |> esc
     end
 end
-function grab!(sym,ex::Expr)
+function grab!(sym,ex::Expr,grab_callheads::Bool=false)
     ex.head == :. && return union!(sym,[ex])      # grab composite name and return
-    start = ex.head==:(call) ? 2 : 1              # don't grab function names
-    foreach(a->grab!(sym,a),ex.args[start:end])   # recurse into args
+    start = ex.head==:(call) ? 2 : 1              # don't grab function names yet
+    foreach(a->grab!(sym,a,grab_callheads),ex.args[start:end])
     ex.args[start:end] = rep.(ex.args[start:end]) # replace composites in args
-    # After args, grab bare-symbol call heads (e.g. `f`, `fill!`) so they are passed
-    # in as kernel arguments rather than resolved by name in the kernel body.
-    # Required because the @kernel is lifted to module scope on the KernelAbstractions
-    # backend (so closure-captured callables would otherwise be invisible) and because
-    # callers may shadow Base names with local helpers (e.g. `fill!` in `measure!`).
-    # Operators (`+`, `*`, `==`, ...) cannot be parameter names, so we skip them and
-    # let them resolve as Base globals. Call heads are pushed *after* their args so
-    # `sym[1]` remains an array-like data symbol — `get_backend(sym[1])` depends on it.
-    if ex.head == :call
+    # When the kernel is lifted to module scope (KA backend), closure-captured
+    # callables and shadowed Base names (e.g. `f` in applyV!, `fill!` in measure!)
+    # must be passed in as arguments. Pushed after args so `sym[1]` stays a data
+    # symbol — `get_backend(sym[1])` depends on it. Operators are skipped (cannot
+    # be parameter names). The SIMD wrapper does NOT need this — the body resolves
+    # callables via the surrounding lexical scope, and adding them as args inflates
+    # the wrapper's arity and triggers a per-call allocation in tight loops.
+    if grab_callheads && ex.head == :call
         head = ex.args[1]
         if head isa Symbol && !Base.isoperator(head)
             union!(sym, [head])
         end
     end
 end
-grab!(sym,ex::Symbol) = union!(sym,[ex]) # grab symbol name
-grab!(sym,ex) = nothing
+grab!(sym,ex::Symbol,grab_callheads::Bool=false) = union!(sym,[ex])
+grab!(sym,ex,grab_callheads::Bool=false) = nothing
 rep(ex) = ex
 rep(ex::Expr) = ex.head == :. ? Symbol(ex.args[2].value) : ex
 joinsymtype(sym::Symbol,symT::Symbol) = Expr(:(::), sym, symT)

--- a/src/util.jl
+++ b/src/util.jl
@@ -139,16 +139,20 @@ macro loop(args...)
     symWtypes = joinsymtype(rep.(sym),symT) # symbols with types: [a::A, b::B, ...]
     @gensym(kern, kern_) # generate unique kernel function names for serial and KA execution
     @static if backend == "KernelAbstractions"
-        return quote
+        # Define the @kernel at module scope (not inside the caller's function body):
+        # when @kernel is generated inside another function, the resulting kernel
+        # functor is a closure-typed object, and Enzyme cannot trace through
+        # KernelAbstractions.construct's generic call to build it. Lifting to
+        # module scope makes it a stable global functor that Enzyme handles.
+        Core.eval(__module__, quote
             @kernel function $kern_($(symWtypes...),@Const(I0)) where {$(symT...)} # replace composite arguments
                 $I = @index(Global,Cartesian)
                 $I += I0
                 @fastmath @inbounds $ex
             end
-            function $kern($(symWtypes...)) where {$(symT...)}
-                $kern_(get_backend($(sym[1])),64)($(sym...),$R[1]-oneunit($R[1]),ndrange=size($R))
-            end
-            $kern($(sym...))
+        end)
+        return quote
+            $kern_(get_backend($(sym[1])),64)($(sym...),$R[1]-oneunit($R[1]),ndrange=size($R))
         end |> esc
     else # backend == "SIMD"
         return quote
@@ -166,8 +170,22 @@ function grab!(sym,ex::Expr)
     start = ex.head==:(call) ? 2 : 1              # don't grab function names
     foreach(a->grab!(sym,a),ex.args[start:end])   # recurse into args
     ex.args[start:end] = rep.(ex.args[start:end]) # replace composites in args
+    # After args, grab bare-symbol call heads (e.g. `f`, `fill!`) so they are passed
+    # in as kernel arguments rather than resolved by name in the kernel body.
+    # Required because the @kernel is lifted to module scope on the KernelAbstractions
+    # backend (so closure-captured callables would otherwise be invisible) and because
+    # callers may shadow Base names with local helpers (e.g. `fill!` in `measure!`).
+    # Operators (`+`, `*`, `==`, ...) cannot be parameter names, so we skip them and
+    # let them resolve as Base globals. Call heads are pushed *after* their args so
+    # `sym[1]` remains an array-like data symbol — `get_backend(sym[1])` depends on it.
+    if ex.head == :call
+        head = ex.args[1]
+        if head isa Symbol && !Base.isoperator(head)
+            union!(sym, [head])
+        end
+    end
 end
-grab!(sym,ex::Symbol) = union!(sym,[ex])          # grab symbol name
+grab!(sym,ex::Symbol) = union!(sym,[ex]) # grab symbol name
 grab!(sym,ex) = nothing
 rep(ex) = ex
 rep(ex::Expr) = ex.head == :. ? Symbol(ex.args[2].value) : ex

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -15,12 +15,14 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
     @test loc(0,I) == SVector(I.I...) .- 1.5
 
     ex,sym = :(a[I,i] = Math.add(p.b[I],func(I,q))),[]
-    WaterLily.grab!(sym,ex)
+    WaterLily.grab!(sym,ex)                            # default: SIMD-style (no call heads)
     @test ex == :(a[I, i] = Math.add(b[I], func(I, q)))
-    # `func` is grabbed as a bare-symbol call head (passed in as a kernel arg) so
-    # the @kernel can be lifted to module scope on the KA backend without losing
-    # closure-captured callables. `Math.add` (qualified) and operators are skipped.
-    @test sym == [:a, :I, :i, :(p.b), :q, :func]
+    @test sym == [:a, :I, :i, :(p.b), :q]
+    # KA-style grab: also collect bare-symbol call heads so the module-scoped
+    # @kernel can receive closure-captured callables / locally-shadowed Base names.
+    ex2,sym2 = :(a[I,i] = Math.add(p.b[I],func(I,q))),[]
+    WaterLily.grab!(sym2,ex2,true)
+    @test sym2 == [:a, :I, :i, :(p.b), :q, :func]
     sym = [:a, :b, :c]
     @test WaterLily.joinsymtype(sym,[:A,:B,:C]) == Expr[:(a::A), :(b::B), :(c::C)]
 

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -17,7 +17,10 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
     ex,sym = :(a[I,i] = Math.add(p.b[I],func(I,q))),[]
     WaterLily.grab!(sym,ex)
     @test ex == :(a[I, i] = Math.add(b[I], func(I, q)))
-    @test sym == [:a, :I, :i, :(p.b), :q]
+    # `func` is grabbed as a bare-symbol call head (passed in as a kernel arg) so
+    # the @kernel can be lifted to module scope on the KA backend without losing
+    # closure-captured callables. `Math.add` (qualified) and operators are skipped.
+    @test sym == [:a, :I, :i, :(p.b), :q, :func]
     sym = [:a, :b, :c]
     @test WaterLily.joinsymtype(sym,[:A,:B,:C]) == Expr[:(a::A), :(b::B), :(c::C)]
 


### PR DESCRIPTION
### Enzyme support for forward + reverse AD on CPU (Claude-assisted)

## Problem

Enzyme.jl could not differentiate WaterLily simulations in either direction:

- **Forward mode** failed at the kernel-launch boundary on the `KernelAbstractions` backend:

  ```
  Enzyme: jl_call calling convention not implemented in forward for
    ... call to KernelAbstractions._construct_ ...
  ```

- **Reverse mode** crashed with an upstream LLVM assertion inside the augmented forward pass:

  ```
  julia: .../llvm/Support/Casting.h:579: cast<Ty>() argument of incompatible type!
  restoreCache at EnzymeLogic.cpp:1941
  ```

  The crash fired regardless of backend (KA or SIMD) and was triggered specifically by code paths reaching the multigrid Poisson solver (and, separately, the `@log` macro).

This PR addresses both: Forward mode on KA-CPU now works. Reverse mode through the full `sim_step!` now works on KA-CPU and SIMD-CPU, matching `ForwardDiff.derivative` to within iterative-solver tolerance.

## Root causes

1. **KA kernel functor was a closure type.** WaterLily's `@loop` macro emitted `@kernel function ... end` *inside the caller's body*. The resulting `Kernel{Backend}` was a closure-typed object that Enzyme's forward mode could not trace through `KernelAbstractions.construct`'s generic `jl_call`. **Module-scope `@kernel`** produces a stable singleton functor that Enzyme handles fine.

2. **Iterative Poisson solver hits an Enzyme reverse-mode LLVM bug.** The augmented forward pass through `MultiLevelPoisson.solver!` aborts in `EnzymeLogic::restoreCache` with an LLVM cast assertion. This is upstream (and unfixable without a custom rule) bug.

3. **`@log` macro triggers the same LLVM assertion.** `@log` expands to `@logmsg _psolver "p"`, which routes through `Base.CoreLogging.logmsg_shim` — its dynamic-dispatch / exception path produces the same `restoreCache` crash, *independent* of the Poisson solver. Bisecting `mom_step!` line-by-line confirmed `@log` is the trigger (variants without `@log` succeed; adding it crashes).

## Fix

### Commit `91d716e` — lift `@loop @kernel` to module scope

In the KA branch of `@loop`, evaluate the `@kernel function ... end` into the calling module at macro-expansion time via `Core.eval(__module__, ...)` instead of returning it for inline expansion. Each call site still gets a gensym-named kernel (so different `@loop` invocations stay distinct functors) but as stable module-scope bindings.

The lift means kernels can no longer capture closure variables from the surrounding scope, so `grab!` is extended to also collect bare-symbol call heads (e.g. `f` in `applyV!(f,c) = @loop ... f(...) ...`, or `fill!` locally defined in `measure!`) and pass them in as kernel arguments. Operators (`+`, `*`, ...) are skipped — they cannot be parameter names. Call heads are pushed *after* their args so `sym[1]` remains a data symbol for `get_backend(sym[1])`.

### Commit `f3f6411` — keep `grab!` call-head capture KA-only

Adding call heads as wrapper args was free for the KA path (kernel was always a typed function) but inflated the SIMD branch's local generic function arity from ~2 to ~6 and triggered ~290 extra allocations per `sim_step!` (5× alloc bump on `sphere/log2p=3 SIMD CPU`). The SIMD wrapper still resolves callables via lexical scope, so it doesn't need them as explicit args.

`grab!` now takes `grab_callheads::Bool`; `@loop` sets it `true` for the KA branch and `false` for SIMD. SIMD allocations return to master baseline.

### Commit `f1c64f1` — `poisson_solve!` wrapper + drop `@log` from `mom_step!`

Adds `poisson_solve!(p::AbstractPoisson) = (solver!(p); nothing)` in `MultiLevelPoisson.jl` and routes `project!` through it. The wrapper provides a stable extension point for AD backends to register custom rules — Enzyme dispatches kwargs functions through `Core.kwcall`, so a rule on `solver!` (which has `tol`/`itmx` kwargs) doesn't fire. `solver!` itself is unchanged and still callable as before.

Also drops the `@log "p"` and `@log "c"` stage markers from `mom_step!`. Pressure-solver iteration data is still logged from inside the solver itself; only the predictor/corrector stage markers are removed. They were the second LLVM-assert trigger.

### Commit `feed49f` — `WaterLilyEnzymeCoreExt` package extension

New extension activated by loading `EnzymeCore` (typically via `using Enzyme`). Registers `EnzymeRules.augmented_primal` and `EnzymeRules.reverse` on `WaterLily.poisson_solve!`. The rule treats the multigrid as a black-box `Ax = z` solve and computes the discrete adjoint via the implicit-function theorem:

- Adjoint solve: `A λ = x̄` — reusing the SAME multigrid since A is symmetric (face coefficients in `L` are shared by adjacent cells, BDIM modulates `μ₀` on faces preserving symmetry).
- Cotangent accumulation:
  - `dz̄ += λ`
  - `dL[I,i] += -(λ_I · x_{I-δᵢ} + λ_{I-δᵢ} · x_I)` (off-diagonal contribution, both copies of `L[I,i]` in the symmetric stencil)
  - `dD[I] += -λ_I · x_I` (diagonal contribution)

Tape stores a copy of the converged primal solution `x` for use in reverse.

## Verification

- `ad_test_reverse_loop.jl`: `@loop` reverse-mode on KA and SIMD — both match `ForwardDiff` exactly (`288.0`, `0.0` rel error).
- `ad_test_reverse_ext.jl`: end-to-end on full `sim_step!` (rotated body, KA-CPU):
  - ForwardDiff: `-0.7749832819419145`
  - Enzyme.Reverse via extension: `-0.6975517892601785`
  - Rel error: `9.99%` — entirely from iterative-solver tolerance gap; tightening Poisson tolerance to `1e-10` brings agreement to `2.4e-5` (~5 sig figs).
- All forward-mode regression numbers from the original `ad_test.jl` preserved (FD CPU `5.632740043288322` unchanged).

## Caveats

- **Cost function must be pressure-shift-invariant.** `sum(p)` produces zero gradient because its uniform cotangent lies in nullspace(Aᵀ) (Neumann-BC pressure is defined up to a constant). Use `sum(u)`, force integrals, etc. ForwardDiff happens to return a non-zero value for `sum(p)` because it sees the specific constant the iterative solver converges to — a numerical artifact. The proper analytic adjoint is exactly 0.
- **Gradient accuracy is bounded by Poisson tolerance.** The default `solver!` uses `tol=1e-4`. For higher-precision gradients, register a wrapper that calls `solver!(p; tol=1e-10, itmx=200)` or similar, and re-register the rule on it.
- **`@log` removal from `mom_step!` is permanent.** Pressure solver iteration data is still logged; only the two stage markers ("p"/"c") are gone. Restoring them requires either fixing the upstream Enzyme `restoreCache` bug or wrapping `@log` in an Enzyme-inactive function.

## Commits

```
91d716e util: lift @loop @kernel to module scope so Enzyme can trace it
f3f6411 util: split grab! call-head capture per backend
f1c64f1 Flow/Poisson: add poisson_solve! wrapper for AD rule dispatch
feed49f ext: add WaterLilyEnzymeCoreExt for reverse-mode Poisson AD
```

## Known related issues (out of scope)

- **Enzyme reverse on GPU** still hits `EnzymeNoDerivativeError: No augmented forward pass found for cuMemcpyHtoDAsync_v2`. Same upstream rule gap that blocks forward-mode GPU. The Poisson custom rule itself works on CUDA arrays — the failure is in Enzyme's missing rules for CUDA driver API calls invoked by `CuArray(::Array)`.
- **Some operations in `mom_step!` emit a cosmetic Enzyme warning** (`TODO forward zero-set of memorycopy used memset rather than runtime type` on the `u⁰ = copy(u)` line in `Flow.jl`). The warning is benign — gradient is correct — and reflects an Enzyme codegen heuristic, not a bug in WaterLily.
