### PR TITLE
Fix some docstrings

### DIFF
--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -19,7 +19,10 @@ function update_body!(a_cpu::Array, sim)
 end
 
 """
-    default_colormap_and_levels(minv, maxv, threshhold, levels)
+    default_colormap_and_levels(clims; threshhold=0.1, nlevels=10, colormap=:seismic, threshhold_color=RGB(1,1,1))
+
+Build a diverging colormap and contour levels spanning `clims=(min,max)`, with `nlevels`
+bands and a `threshhold_color` band straddling zero of half-width `threshhold`.
 """
 function default_colormap_and_levels(clims; threshhold=0.1, nlevels=10, colormap=:seismic, threshhold_color=RGB(1,1,1))
     @assert clims[2] > clims[1] "clims argument does not satisfy clims[2] > clims[1]"
@@ -31,9 +34,7 @@ function default_colormap_and_levels(clims; threshhold=0.1, nlevels=10, colormap
     colors, [lowerrange; upperrange]
 end
 
-"""
-Default visualization function for 2D/3D simulations
-"""
+
 function ω2D_viz!(cpu_array, sim)
     a = sim.flow.σ
     WaterLily.@inside a[I] = WaterLily.curl(3,I,sim.flow.u)
@@ -44,6 +45,9 @@ function ω3D_viz!(cpu_array, sim)
     WaterLily.@inside a[I] = WaterLily.ω_mag(I,sim.flow.u)
     copyto!(cpu_array, ad_f(sim)(@view a[inside(a)]))
 end
+"""
+Default visualization function for 2D/3D simulations
+"""
 ω_viz!(n) = n == 2 ? ω2D_viz! : ω3D_viz!
 
 """

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -119,7 +119,7 @@ BDIM-masked surface normal.
 end
 
 """
-    pressure_force(sim::Simulation)
+    pressure_force(sim)
 
 Compute the pressure force on an immersed body.
 """
@@ -140,7 +140,7 @@ Rate-of-strain tensor.
 @inline S(I::CartesianIndex{D},u) where D = SMatrix{D,D}((∂(i,j,I,u)+∂(j,i,I,u))/2 for i ∈ 1:D, j ∈ 1:D)
 
 """
-    viscous_force(sim::Simulation)
+    viscous_force(sim)
 
 Compute the viscous force on an immersed body.
 """
@@ -154,7 +154,7 @@ function viscous_force(u,ν,df,body,t=0)
 end
 
 """
-    total_force(sim::Simulation)
+    total_force(sim)
 
 Compute the total force on an immersed body.
 """
@@ -162,7 +162,7 @@ total_force(sim) = pressure_force(sim) .+ viscous_force(sim)
 
 using LinearAlgebra: cross
 """
-    pressure_moment(x₀,sim::Simulation)
+    pressure_moment(x₀,sim)
 
 Computes the pressure moment on an immersed body relative to point x₀.
 """
@@ -176,7 +176,7 @@ function pressure_moment(x₀,p,df,body,t=0)
 end
 
 """
-    viscous_moment(x₀,sim::Simulation)
+    viscous_moment(x₀,sim)
 
 Computes the viscous moment on an immersed body relative to point x₀.
 """
@@ -190,7 +190,7 @@ function viscous_moment(x₀,u,ν,df,body,t=0)
 end
 
 """
-    total_moment(x₀,sim::Simulation)
+    total_moment(x₀,sim)
 
 Computes the total (pressure + viscous) moment on an immersed body relative to point x₀.
 """

--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -53,7 +53,7 @@ prolongate!(a,b,c) = @inside a[I] = b[down(I,c)]
 # keep coarsening while ANY direction is still divisible (semi-coarsening)
 @inline divisible(l::Poisson) = any(size(l.x) .|> divisible)
 """
-    MultiLevelPoisson{N,M}
+    MultiLevelPoisson{T::Float, S<:AbstractArray{T,D}, V<:AbstractArray{T,D+1}}
 
 Composite type used to solve the pressure Poisson equation with a [geometric multigrid](https://en.wikipedia.org/wiki/Multigrid_method) method.
 The only variable is `levels`, a vector of nested `Poisson` systems.

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -1,7 +1,7 @@
 abstract type AbstractPoisson{T,S,V} end
 
 """
-    Poisson{N,M}
+    Poisson{T::Float, S<:AbstractArray{T,D}, V<:AbstractArray{T,D+1}}
 
 Composite type for conservative variable coefficient Poisson equations:
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -87,7 +87,7 @@ Constructor for a WaterLily.jl simulation:
         Called after `flow_ctor` with the constructed flow as argument.
         Used by downstream packages (e.g. BiotSavartBCs.jl) to inject a custom `AbstractPoisson` subtype.
 
-See files in `examples` folder for examples.
+See the repository [WaterLily-Examples](https://github.com/WaterLily-jl/WaterLily-Examples) for more examples.
 """
 mutable struct Simulation <: AbstractSimulation
     U :: Number # velocity scale

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -114,7 +114,7 @@ end
 
 time(sim::AbstractSimulation) = time(sim.flow)
 """
-    sim_time(sim::Simulation)
+    sim_time(sim::AbstractSimulation)
 
 Return the current dimensionless time of the simulation `tU/L`
 where `t=sum(Δt)`, and `U`,`L` are the simulation velocity and length
@@ -145,7 +145,7 @@ function sim_step!(sim::AbstractSimulation;remeasure=true,udf=nothing,kwargs...)
 end
 
 """
-    measure!(sim::Simulation,t=timeNext(sim))
+    measure!(sim::AbstractSimulation,t=sum(sim.flow.Δt))
 
 Measure a dynamic `body` to update the `flow` and `pois` coefficients.
 """
@@ -161,7 +161,7 @@ Prints information on the current state of a simulation.
 sim_info(sim::AbstractSimulation) = @printf "tU/L=%.4f, Δt=%.3f\n" sim_time(sim) sim.flow.Δt[end]
 
 """
-    perturb!(sim; noise=0.1)
+    perturb!(sim::AbstractSimulations; noise=0.1)
 Perturb the velocity field of a simulation with `noise` level with respect to velocity scale `U`.
 """
 perturb!(sim::AbstractSimulation; noise=0.1) = sim.flow.u .+= randn(size(sim.flow.u))*sim.U*noise |> typeof(sim.flow.u).name.wrapper

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -37,6 +37,20 @@ include("RigidMap.jl")
 export RigidMap,setmap
 
 """
+    check_fn(f,N,T,nargs)
+
+Check a user-supplied BC/IC function `f(i,x)` or `f(i,x,t)` has `nargs`
+arguments and is type-stable, returning `T` for every `i in 1:N`. No-op if
+`f` is not a `Function`.
+"""
+check_fn(f,N,T,nargs) = nothing
+function check_fn(f::Function,N,T,nargs)
+    @assert first(methods(f)).nargs==nargs+1 "$f signature needs $nargs arguments"
+    @assert all(typeof.(ntuple(i->f(i,xtargs(Val{}(nargs),N,T)...),N)).==T) "$f is not type stable"
+end
+xtargs(::Val{2},N,T) = (zeros(SVector{N,T}),)
+xtargs(::Val{3},N,T) = (zeros(SVector{N,T}),zero(T))
+"""
     Simulation(dims::NTuple, uBC::Union{NTuple,Function}, L::Number;
                U=nothing, Δt=0.25, ν=0., ϵ=1, g=nothing,
                u0=nothing, perdir=(), exitBC=false, λ=quick,
@@ -75,14 +89,6 @@ Constructor for a WaterLily.jl simulation:
 
 See files in `examples` folder for examples.
 """
-check_fn(f,N,T,nargs) = nothing
-function check_fn(f::Function,N,T,nargs)
-    @assert first(methods(f)).nargs==nargs+1 "$f signature needs $nargs arguments"
-    @assert all(typeof.(ntuple(i->f(i,xtargs(Val{}(nargs),N,T)...),N)).==T) "$f is not type stable"
-end
-xtargs(::Val{2},N,T) = (zeros(SVector{N,T}),)
-xtargs(::Val{3},N,T) = (zeros(SVector{N,T}),zero(T))
-
 mutable struct Simulation <: AbstractSimulation
     U :: Number # velocity scale
     L :: Number # length scale

--- a/src/core.jl
+++ b/src/core.jl
@@ -31,7 +31,7 @@ Replace jᵗʰ component of CartesianIndex with k
 CIj(j,I::CartesianIndex{d},k) where d = CI(ntuple(i -> i==j ? k : I[i], d))
 
 """
-    δ(i,N::Int)
+    δ(i,::Val{N})
     δ(i,I::CartesianIndex{N}) where {N}
 
 Return a CartesianIndex of dimension `N` which is one at index `i` and zero elsewhere.
@@ -169,10 +169,10 @@ joinsymtype(sym,symT) = zip(sym,symT) .|> x->joinsymtype(x...)
 
 using StaticArrays
 """
-    loc(i,I) = loc(Ii)
+    loc(i,I,T) = loc(Ii,T)
 
 Location in space of the cell at CartesianIndex `I` at face `i`.
-Using `i=0` returns the cell center s.t. `loc = I`.
+Using `i=0` returns the cell center s.t. `loc = I`. `T` sets the return number type.
 """
 @inline loc(i,I::CartesianIndex{N},T=Float32) where N = SVector{N,T}(I.I .- T(1.5) .- δ(i,I).I ./T(2))
 @inline loc(Ii::CartesianIndex,T=Float32) = loc(last(Ii),Base.front(Ii),T)
@@ -190,12 +190,15 @@ function slice(dims::NTuple{N},i,j,low=1) where N
 end
 
 """
-    BC!(a,A)
+    BC!(a,U,saveexit=false,perdir=(),t=0)
 
 Apply boundary conditions to the ghost cells of a _vector_ field. A Dirichlet
-condition `a[I,i]=A[i]` is applied to the vector component _normal_ to the domain
+condition `a[I,i]=U[i]` is applied to the vector component _normal_ to the domain
 boundary. For example `aₓ(x)=Aₓ ∀ x ∈ minmax(X)`. A zero Neumann condition
-is applied to the tangential components.
+is applied to the tangential components. `saveexit` skips overwriting the
+exit-face normal component (except in the `x`-direction). `perdir` lists the
+dimensions using periodic BCs instead. `t` is passed to `U` when it is a
+function `(i,x,t)->...`.
 """
 BC!(a,U,saveexit=false,perdir=(),t=0) = BC!(a,(i,x,t)->U[i],saveexit,perdir,t)
 function BC!(a,uBC::Function,saveexit=false,perdir=(),t=0)
@@ -219,7 +222,7 @@ function BC!(a,uBC::Function,saveexit=false,perdir=(),t=0)
 end
 
 """
-    exitBC!(u,u⁰,U,Δt)
+    exitBC!(u,u⁰,Δt)
 
 Apply a 1D convection scheme to fill the ghost cell on the exit of the domain.
 """

--- a/src/util.jl
+++ b/src/util.jl
@@ -110,15 +110,15 @@ function spread!(sim3D::AbstractSimulation, sim2D::AbstractSimulation; dim=3, ϵ
 end
 
 """
-    spread!(src:AbstractArray{T,N}, dest::AbstractArray{T,N+1}; ϵ=0, dims=3)
+    spread!(src:AbstractArray{T,N}, dest::AbstractArray{T,N+1}; ϵ=0, dim=3)
 
 Spreads a `N` dim field into a `N+1` field. The parameter `ϵ` sets the random noise added to the spread and
-`dims` specifies the dimension along which the spreading is done.
+`dim` specifies the dimension along which the spreading is done.
 
 ```julia
 dest = zeros(20,10,5)
 src  = rand(20,10)
-WaterLily.spread!(src, dest; ϵ=0.01, dims=3)
+WaterLily.spread!(src, dest; ϵ=0.01, dim=3)
 ```
 """
 spread!(dest::AbstractArray{T,3}, src::AbstractArray{T,2}; dim=3, ϵ=zero(T)) where T = (@loop dest[I] = src[dropindex(I,dim)]+ϵ*rand() over I in CartesianIndices(dest))


### PR DESCRIPTION
1. Docstrings of `Simulation` now truely attach to `Simulation` instead of `check_fn`.
2. Fix other docstring mismatches and misplacement.