### PR TITLE
New median without conditionals for QUICK

### DIFF
--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -24,16 +24,9 @@ end
     end
     return s/2
 end
-function median(a,b,c)
-    if a>b
-        b>=c && return b
-        a>c && return c
-    else
-        b<=c && return b
-        a<c && return c
-    end
-    return a
-end
+# Branch-free median: the if/else form compiled to conditional jumps whose mispredictions
+# made `conv_diff!` data-dependent (up to 2× slower on noise-like velocity fields).
+@fastmath median(a,b,c) = max(min(a,b),min(max(a,b),c))
 
 function conv_diff!(r,u,Φ,λ::F;ν=0.1,perdir=()) where {F}
     r .= zero(eltype(r))

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -24,8 +24,6 @@ end
     end
     return s/2
 end
-# Branch-free median: the if/else form compiled to conditional jumps whose mispredictions
-# made `conv_diff!` data-dependent (up to 2× slower on noise-like velocity fields).
 @fastmath median(a,b,c) = max(min(a,b),min(max(a,b),c))
 
 function conv_diff!(r,u,Φ,λ::F;ν=0.1,perdir=()) where {F}

--- a/test/test_flow.jl
+++ b/test/test_flow.jl
@@ -171,3 +171,9 @@ end
         @test !any(isnan.(sim.pois.n))
     end
 end
+
+@testset "median" begin
+    for (a,b,c) in ((1,2,3),(3,2,1),(2,3,1),(1,3,2),(2,1,3),(3,1,2),(1,1,2),(2,2,2),(-1.5f0,0.25f0,-0.5f0))
+        @test WaterLily.median(a,b,c) == sort([a,b,c])[2]
+    end
+end


### PR DESCRIPTION
Replaces the if/else in `median(a,b,c)` with `max(min(a,b), min(max(a,b), c))` (no conditionals). Speeds up `sim_step!` by 8-40% on the CPU backends. The speedup comes from being able to vectorize the function on compilation, and the fact that "noisy" velocity fields were randomly branching across the conditionals of the function, instead of having a constant (lower) computational cost.

## LLM report

The old `median` compiled to conditional jumps whose outcomes depend on the ordering of the three stencil values, so the branch predictor learns them on smooth velocity fields but not on noise-like ones (for example the near-zero transverse velocity of a converged far field, where every ordering is a coin flip). On a 256×96×96 sphere case (SIMD backend, single thread) `conv_diff!` took 78 ms on a smooth field, 97 ms on a converged one and 151 ms on a field with random-sign transverse perturbations, against 44/44/72 ms with the branch-free `cds` scheme. With the branch-free median it takes 66/66/92 ms: the data dependence is gone and the limiter is 15 to 32 % cheaper. Selecting the upwind stencil in `ϕu` with `ifelse` (evaluating both branches) was also tried and is slower (102 ms), so that branch is kept. The KernelAbstractions CPU backend benefits even more because the branch-free kernel body now vectorises.

**Benchmarks.** [WaterLily-Benchmarks](https://github.com/WaterLily-jl/WaterLily-Benchmarks) (`developed-checkpoints` branch): `sim_step!` timed from the stored developed-flow checkpoints, each of 5 runs reset to the checkpoint and timing 25 individual steps; Float32; Julia 1.11.5; i7-13700H (6P+8E cores) + RTX 4060 Laptop GPU. `CPUx01` is the SIMD backend, `CPUx04` KernelAbstractions with 4 threads, `GPU-NVIDIA` CuArray. Base for `Δ` and `Speedup`: `master` `08b932f`; this branch is `22208cd`.

```
Benchmark environment: tgv sim_step! (5 runs × 25 steps)
▶ log2p = 6
┌────────────┬───────────────────┬────────┬─────────┬───────┬───────┬───────┬───────┬─────────────┬───────┬─────────┬───────┐
│  Backend   │     WaterLily     │ Julia  │   FP    │ Alloc │  Min  │  Med  │  Max  │    Cost     │   Δ   │ Speedup │ Noise │
│            │                   │        │         │  [k]  │ [ms]  │ [ms]  │ [ms]  │ [ns/DOF/dt] │  [%]  │         │  [%]  │
├────────────┼───────────────────┼────────┼─────────┼───────┼───────┼───────┼───────┼─────────────┼───────┼─────────┼───────┤
│     CPUx01 │ branchless-median │ 1.11.5 │ Float32 │   0.1 │ 36.09 │ 36.91 │ 37.75 │      137.67 │ -28.9 │    1.41 │   1.7 │
│     CPUx01 │            master │ 1.11.5 │ Float32 │   0.1 │ 50.77 │ 51.08 │ 51.34 │      193.66 │     - │    1.00 │   0.5 │
│     CPUx04 │ branchless-median │ 1.11.5 │ Float32 │  13.7 │ 15.91 │ 16.88 │ 17.69 │       60.70 │ -39.8 │    3.19 │   4.1 │
│     CPUx04 │            master │ 1.11.5 │ Float32 │  13.7 │ 26.44 │ 26.92 │ 27.36 │      100.88 │     - │    1.92 │   1.3 │
│ GPU-NVIDIA │ branchless-median │ 1.11.5 │ Float32 │  21.5 │  3.64 │  3.89 │  3.90 │       13.90 │  +1.0 │   13.93 │   3.6 │
│ GPU-NVIDIA │            master │ 1.11.5 │ Float32 │  21.4 │  3.61 │  3.95 │  3.97 │       13.77 │     - │   14.07 │   4.3 │
└────────────┴───────────────────┴────────┴─────────┴───────┴───────┴───────┴───────┴─────────────┴───────┴─────────┴───────┘
▶ log2p = 7
┌────────────┬───────────────────┬────────┬─────────┬───────┬────────┬────────┬────────┬─────────────┬───────┬─────────┬───────┐
│  Backend   │     WaterLily     │ Julia  │   FP    │ Alloc │  Min   │  Med   │  Max   │    Cost     │   Δ   │ Speedup │ Noise │
│            │                   │        │         │  [k]  │  [ms]  │  [ms]  │  [ms]  │ [ns/DOF/dt] │  [%]  │         │  [%]  │
├────────────┼───────────────────┼────────┼─────────┼───────┼────────┼────────┼────────┼─────────────┼───────┼─────────┼───────┤
│     CPUx01 │ branchless-median │ 1.11.5 │ Float32 │   0.0 │ 281.08 │ 281.75 │ 284.29 │      134.03 │ -27.9 │    1.39 │   0.5 │
│     CPUx01 │            master │ 1.11.5 │ Float32 │   0.0 │ 390.09 │ 391.18 │ 391.48 │      186.01 │     - │    1.00 │   0.1 │
│     CPUx04 │ branchless-median │ 1.11.5 │ Float32 │  14.6 │ 126.12 │ 128.93 │ 137.81 │       60.14 │ -28.2 │    3.09 │   3.6 │
│     CPUx04 │            master │ 1.11.5 │ Float32 │  14.6 │ 175.68 │ 181.51 │ 182.29 │       83.77 │     - │    2.22 │   1.5 │
│ GPU-NVIDIA │ branchless-median │ 1.11.5 │ Float32 │  23.1 │  22.13 │  22.69 │  23.74 │       10.55 │  -1.7 │   17.63 │   2.7 │
│ GPU-NVIDIA │            master │ 1.11.5 │ Float32 │  23.1 │  22.51 │  22.85 │  23.25 │       10.73 │     - │   17.33 │   1.2 │
└────────────┴───────────────────┴────────┴─────────┴───────┴────────┴────────┴────────┴─────────────┴───────┴─────────┴───────┘
Benchmark environment: sphere sim_step! (5 runs × 25 steps)
▶ log2p = 3
┌────────────┬───────────────────┬────────┬─────────┬───────┬───────┬───────┬───────┬─────────────┬───────┬─────────┬───────┐
│  Backend   │     WaterLily     │ Julia  │   FP    │ Alloc │  Min  │  Med  │  Max  │    Cost     │   Δ   │ Speedup │ Noise │
│            │                   │        │         │  [k]  │ [ms]  │ [ms]  │ [ms]  │ [ns/DOF/dt] │  [%]  │         │  [%]  │
├────────────┼───────────────────┼────────┼─────────┼───────┼───────┼───────┼───────┼─────────────┼───────┼─────────┼───────┤
│     CPUx01 │ branchless-median │ 1.11.5 │ Float32 │   0.0 │ 37.81 │ 38.37 │ 38.56 │      128.20 │ -16.9 │    1.20 │   0.8 │
│     CPUx01 │            master │ 1.11.5 │ Float32 │   0.0 │ 45.48 │ 45.67 │ 46.69 │      154.23 │     - │    1.00 │   1.1 │
│     CPUx04 │ branchless-median │ 1.11.5 │ Float32 │  14.4 │ 15.59 │ 17.56 │ 20.13 │       52.87 │ -35.8 │    2.92 │  12.0 │
│     CPUx04 │            master │ 1.11.5 │ Float32 │  14.4 │ 24.30 │ 24.94 │ 28.29 │       82.41 │     - │    1.87 │   6.8 │
│ GPU-NVIDIA │ branchless-median │ 1.11.5 │ Float32 │  23.1 │  3.87 │  3.89 │  3.90 │       13.13 │  -1.0 │   11.74 │   0.2 │
│ GPU-NVIDIA │            master │ 1.11.5 │ Float32 │  23.1 │  3.91 │  3.93 │  3.96 │       13.27 │     - │   11.62 │   0.5 │
└────────────┴───────────────────┴────────┴─────────┴───────┴───────┴───────┴───────┴─────────────┴───────┴─────────┴───────┘
▶ log2p = 4
┌────────────┬───────────────────┬────────┬─────────┬───────┬────────┬────────┬────────┬─────────────┬───────┬─────────┬───────┐
│  Backend   │     WaterLily     │ Julia  │   FP    │ Alloc │  Min   │  Med   │  Max   │    Cost     │   Δ   │ Speedup │ Noise │
│            │                   │        │         │  [k]  │  [ms]  │  [ms]  │  [ms]  │ [ns/DOF/dt] │  [%]  │         │  [%]  │
├────────────┼───────────────────┼────────┼─────────┼───────┼────────┼────────┼────────┼─────────────┼───────┼─────────┼───────┤
│     CPUx01 │ branchless-median │ 1.11.5 │ Float32 │   0.0 │ 309.56 │ 312.05 │ 317.56 │      131.21 │  -7.5 │    1.08 │   1.0 │
│     CPUx01 │            master │ 1.11.5 │ Float32 │   0.0 │ 334.75 │ 335.75 │ 338.61 │      141.88 │     - │    1.00 │   0.4 │
│     CPUx04 │ branchless-median │ 1.11.5 │ Float32 │  15.4 │ 127.78 │ 128.31 │ 134.23 │       54.16 │ -28.4 │    2.62 │   2.1 │
│     CPUx04 │            master │ 1.11.5 │ Float32 │  15.4 │ 178.55 │ 182.14 │ 187.85 │       75.68 │     - │    1.87 │   2.1 │
│ GPU-NVIDIA │ branchless-median │ 1.11.5 │ Float32 │  24.8 │  23.59 │  23.88 │  24.00 │       10.00 │  +0.5 │   14.19 │   0.7 │
│ GPU-NVIDIA │            master │ 1.11.5 │ Float32 │  24.8 │  23.48 │  23.86 │  24.39 │        9.95 │     - │   14.26 │   1.5 │
└────────────┴───────────────────┴────────┴─────────┴───────┴────────┴────────┴────────┴─────────────┴───────┴─────────┴───────┘
Benchmark environment: jelly sim_step! (5 runs × 25 steps)
▶ log2p = 5
┌────────────┬───────────────────┬────────┬─────────┬───────┬────────┬────────┬────────┬─────────────┬───────┬─────────┬───────┐
│  Backend   │     WaterLily     │ Julia  │   FP    │ Alloc │  Min   │  Med   │  Max   │    Cost     │   Δ   │ Speedup │ Noise │
│            │                   │        │         │  [k]  │  [ms]  │  [ms]  │  [ms]  │ [ns/DOF/dt] │  [%]  │         │  [%]  │
├────────────┼───────────────────┼────────┼─────────┼───────┼────────┼────────┼────────┼─────────────┼───────┼─────────┼───────┤
│     CPUx01 │ branchless-median │ 1.11.5 │ Float32 │   0.6 │ 142.76 │ 143.51 │ 143.77 │     1089.14 │  -1.8 │    1.02 │   0.3 │
│     CPUx01 │            master │ 1.11.5 │ Float32 │   0.6 │ 145.41 │ 146.14 │ 146.82 │     1109.38 │     - │    1.00 │   0.4 │
│     CPUx04 │ branchless-median │ 1.11.5 │ Float32 │  53.9 │  54.78 │  56.05 │  60.13 │      417.96 │ -11.1 │    2.65 │   4.5 │
│     CPUx04 │            master │ 1.11.5 │ Float32 │  53.9 │  61.64 │  62.91 │  76.17 │      470.26 │     - │    2.36 │   9.7 │
│ GPU-NVIDIA │ branchless-median │ 1.11.5 │ Float32 │  53.5 │   8.89 │   8.92 │   9.07 │       67.80 │  +0.9 │   16.36 │   1.0 │
│ GPU-NVIDIA │            master │ 1.11.5 │ Float32 │  53.5 │   8.81 │   8.86 │   9.03 │       67.20 │     - │   16.51 │   1.1 │
└────────────┴───────────────────┴────────┴─────────┴───────┴────────┴────────┴────────┴─────────────┴───────┴─────────┴───────┘
▶ log2p = 6
┌────────────┬───────────────────┬────────┬─────────┬───────┬────────┬────────┬────────┬─────────────┬───────┬─────────┬───────┐
│  Backend   │     WaterLily     │ Julia  │   FP    │ Alloc │  Min   │  Med   │  Max   │    Cost     │   Δ   │ Speedup │ Noise │
│            │                   │        │         │  [k]  │  [ms]  │  [ms]  │  [ms]  │ [ns/DOF/dt] │  [%]  │         │  [%]  │
├────────────┼───────────────────┼────────┼─────────┼───────┼────────┼────────┼────────┼─────────────┼───────┼─────────┼───────┤
│     CPUx01 │ branchless-median │ 1.11.5 │ Float32 │   0.6 │ 808.66 │ 812.59 │ 816.74 │      771.20 │  -1.5 │    1.01 │   0.4 │
│     CPUx01 │            master │ 1.11.5 │ Float32 │   0.6 │ 820.57 │ 823.45 │ 835.87 │      782.56 │     - │    1.00 │   0.7 │
│     CPUx04 │ branchless-median │ 1.11.5 │ Float32 │ 114.7 │ 295.48 │ 297.57 │ 318.73 │      281.79 │ -11.0 │    2.78 │   3.3 │
│     CPUx04 │            master │ 1.11.5 │ Float32 │ 114.7 │ 332.01 │ 338.55 │ 352.04 │      316.63 │     - │    2.47 │   2.4 │
│ GPU-NVIDIA │ branchless-median │ 1.11.5 │ Float32 │  49.5 │  27.65 │  29.26 │  30.21 │       26.37 │  +0.8 │   29.68 │   3.9 │
│ GPU-NVIDIA │            master │ 1.11.5 │ Float32 │  49.6 │  27.44 │  28.56 │  29.84 │       26.17 │     - │   29.91 │   3.9 │
└────────────┴───────────────────┴────────┴─────────┴───────┴────────┴────────┴────────┴─────────────┴───────┴─────────┴───────┘
```

Headline: SIMD −29 % (tgv), −17/−8 % (sphere), −2 % (jelly); KA×4 −28…−40 % (tgv, sphere), −11 % (jelly); GPU within noise (no branch predictor to help, and the divergence cost was already there). The jelly case gains least because its step is dominated by the Biot-Savart pressure solve and the per-step `measure!`, not by `conv_diff!`. Allocations are unchanged.

**Tests.** Adds a `median` unit test (middle value for every ordering, including ties and negative Float32 inputs). Results are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
