### PR TITLE
Deforming body source

### DIFF
--- a/src/Body.jl
+++ b/src/Body.jl
@@ -48,11 +48,6 @@ function measure!(a::AbstractFlow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where 
     @loop fill!(a.μ₀,a.μ₁,a.V,a.σ,I) over I ∈ inside(a.p)
     BC!(a.μ₀,zeros(SVector{N,T}),false,a.perdir) # BC on μ₀, don't fill normal component yet
     BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)
-    # div(V)≠0 cannot be corrected inside the body, we must remove it
-    @inside a.σᵥ[I] = (1+diag(I,a.μ₀)/(2N))*div(I,a.V)
-    # Remove the mean to avoid the pressure drifting
-    s = sum(a.σᵥ)/length(inside(a.σᵥ)) # ghosts are never written, so the full sum is exact
-    abs(s) > 2eps(T) && (@inside a.σᵥ[I] = a.σᵥ[I]-s)
 end
 
 # Convolution kernel and its moments

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -48,14 +48,9 @@ function measure!(a::AbstractFlow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where 
     @loop fill!(a.μ₀,a.μ₁,a.V,a.σ,I) over I ∈ inside(a.p)
     BC!(a.μ₀,zeros(SVector{N,T}),false,a.perdir) # BC on μ₀, don't fill normal component yet
     BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)
-    # A *deforming* body has div(V)≠0, and BDIM sets u=V in every cell closed on all faces,
-    # so demanding div(u)=0 there asks the solver to undo the prescribed deformation in rows
-    # the operator cannot touch. Store the body's dilatation, weighted by the solid fraction
-    # -diag(I,μ₀)/2N -- the operator's own diagonal, so it is exactly 1 where the row is null
-    # and 0 in open fluid -- for `mom_project!` to subtract from the source.
+    # div(V)≠0 cannot be corrected inside the body, we must remove it
     @inside a.σᵥ[I] = (1+diag(I,a.μ₀)/(2N))*div(I,a.V)
-    # Remove its mean: a source outside the range of the singular operator makes the pressure
-    # drift step on step until Float32 round-off in the residual swamps the solver tolerance.
+    # Remove the mean to avoid the pressure drifting
     s = sum(a.σᵥ)/length(inside(a.σᵥ)) # ghosts are never written, so the full sum is exact
     abs(s) > 2eps(T) && (@inside a.σᵥ[I] = a.σᵥ[I]-s)
 end

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -48,6 +48,16 @@ function measure!(a::AbstractFlow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where 
     @loop fill!(a.μ₀,a.μ₁,a.V,a.σ,I) over I ∈ inside(a.p)
     BC!(a.μ₀,zeros(SVector{N,T}),false,a.perdir) # BC on μ₀, don't fill normal component yet
     BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)
+    # A *deforming* body has div(V)≠0, and BDIM sets u=V in every cell closed on all faces,
+    # so demanding div(u)=0 there asks the solver to undo the prescribed deformation in rows
+    # the operator cannot touch. Store the body's dilatation, weighted by the solid fraction
+    # -diag(I,μ₀)/2N -- the operator's own diagonal, so it is exactly 1 where the row is null
+    # and 0 in open fluid -- for `mom_project!` to subtract from the source.
+    @inside a.σᵥ[I] = (1+diag(I,a.μ₀)/(2N))*div(I,a.V)
+    # Remove its mean: a source outside the range of the singular operator makes the pressure
+    # drift step on step until Float32 round-off in the residual swamps the solver tolerance.
+    s = sum(a.σᵥ)/length(inside(a.σᵥ)) # ghosts are never written, so the full sum is exact
+    abs(s) > 2eps(T) && (@inside a.σᵥ[I] = a.σᵥ[I]-s)
 end
 
 # Convolution kernel and its moments

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -113,7 +113,6 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     V :: Vf # body velocity vector
     μ₀:: Vf # zeroth-moment vector
     μ₁:: Tf # first-moment tensor field
-    σᵥ:: Sf # body dilatation source, div(V) masked by the solid fraction
     # Non-fields
     uBC :: Union{NTuple{D,Number},Function} # domain boundary values/function
     Δt:: Vector{T} # time step (stored in CPU memory)
@@ -134,9 +133,8 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> mem, zeros(T, Ng) |> mem, zeros(T, Ng) |> mem
         V, μ₀, μ₁ = zeros(T, Nd) |> mem, ones(T, Nd) |> mem, zeros(T, Ng..., D, D) |> mem
-        σᵥ = zeros(T, Ng) |> mem # stays zero outside the interior, so a full sum is exact
         BC!(μ₀,ntuple(zero, D),false,perdir)
-        new{D,T,typeof(p),typeof(u),typeof(μ₁),typeof(λ)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,σᵥ,uBC,T[Δt],T(ν),g,exitBC,perdir,λ)
+        new{D,T,typeof(p),typeof(u),typeof(μ₁),typeof(λ)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,uBC,T[Δt],T(ν),g,exitBC,perdir,λ)
     end
 end
 
@@ -217,8 +215,12 @@ The source carries `flow.σᵥ`, the body's own dilatation, so that a *deforming
 asked to be divergence-free; see `measure!`. It is zero for a rigid body or no body.
 """
 function mom_project!(a::AbstractFlow{D,T}, b::AbstractPoisson, w, t) where {D,T}
-    dt = T(w)*a.Δt[end]
-    @inside b.z[I] = div(I,a.u)-a.σᵥ[I]; b.x .*= dt # set source term & solution IC
+    dt = T(w)*a.Δt[end]; a.σ .= zero(T)
+    # div(V)≠0 cannot be corrected inside the body, we must remove it
+    @inside a.σ[I] = (1+diag(I,a.μ₀)/(2D))*div(I,a.V)
+    # Remove the mean to avoid the pressure drifting
+    s = sum(a.σ)/length(inside(a.σ)) # ghosts are never written, so the full sum is exact
+    @inside b.z[I] = div(I,a.u)-a.σ[I]+s; b.x .*= dt # set source term & solution IC
     solver!(b)
     for i ∈ 1:ndims(a.p)  # apply solution and unscale to recover pressure
         @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -210,9 +210,6 @@ end
 Projection phase of `mom_step!`: solve the pressure Poisson equation, correct
 the velocity by `w·Δt·∇p`, and re-enforce BCs.
 On return `a.u` is divergence-free and BC-consistent.
-
-The source carries `flow.σᵥ`, the body's own dilatation, so that a *deforming* body is not
-asked to be divergence-free; see `measure!`. It is zero for a rigid body or no body.
 """
 function mom_project!(a::AbstractFlow{D,T}, b::AbstractPoisson, w, t) where {D,T}
     dt = T(w)*a.Δt[end]; a.σ .= zero(T)

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -113,6 +113,7 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     V :: Vf # body velocity vector
     μ₀:: Vf # zeroth-moment vector
     μ₁:: Tf # first-moment tensor field
+    σᵥ:: Sf # body dilatation source, div(V) masked by the solid fraction
     # Non-fields
     uBC :: Union{NTuple{D,Number},Function} # domain boundary values/function
     Δt:: Vector{T} # time step (stored in CPU memory)
@@ -133,8 +134,9 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> mem, zeros(T, Ng) |> mem, zeros(T, Ng) |> mem
         V, μ₀, μ₁ = zeros(T, Nd) |> mem, ones(T, Nd) |> mem, zeros(T, Ng..., D, D) |> mem
+        σᵥ = zeros(T, Ng) |> mem # stays zero outside the interior, so a full sum is exact
         BC!(μ₀,ntuple(zero, D),false,perdir)
-        new{D,T,typeof(p),typeof(u),typeof(μ₁),typeof(λ)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,uBC,T[Δt],T(ν),g,exitBC,perdir,λ)
+        new{D,T,typeof(p),typeof(u),typeof(μ₁),typeof(λ)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,σᵥ,uBC,T[Δt],T(ν),g,exitBC,perdir,λ)
     end
 end
 
@@ -210,10 +212,13 @@ end
 Projection phase of `mom_step!`: solve the pressure Poisson equation, correct
 the velocity by `w·Δt·∇p`, and re-enforce BCs.
 On return `a.u` is divergence-free and BC-consistent.
+
+The source carries `flow.σᵥ`, the body's own dilatation, so that a *deforming* body is not
+asked to be divergence-free; see `measure!`. It is zero for a rigid body or no body.
 """
 function mom_project!(a::AbstractFlow{D,T}, b::AbstractPoisson, w, t) where {D,T}
     dt = T(w)*a.Δt[end]
-    @inside b.z[I] = div(I,a.u); b.x .*= dt # set source term & solution IC
+    @inside b.z[I] = div(I,a.u)-a.σᵥ[I]; b.x .*= dt # set source term & solution IC
     solver!(b)
     for i ∈ 1:ndims(a.p)  # apply solution and unscale to recover pressure
         @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)

--- a/test/test_flow.jl
+++ b/test/test_flow.jl
@@ -180,12 +180,9 @@ end
 
 @testset "Deforming body dilatation" begin
     # A body whose volume changes has div(V)≠0, and BDIM sets u=V in every cell closed on
-    # all faces, so div(u)=div(V) there -- in rows whose Poisson diagonal is zero. `flow.σᵥ`
-    # carries that dilatation out of the source. Both halves matter: drop σᵥ and an
-    # irreducible residual is left behind, but subtract the body's flux div((1-μ₀)V) instead
-    # and the source telescopes to zero net volume, so the body stops displacing fluid.
-    closed_cell(I::CartesianIndex{D},μ₀) where D =
-        all(ntuple(i->(μ₀[I,i] ≤ 1f-6) & (μ₀[I+δ(i,I),i] ≤ 1f-6), Val(D)))
+    # all faces, so div(u)=div(V) there, in rows whose Poisson diagonal is zero. We must`
+    # carry that dilatation out of the source
+    closed_cell(I::CartesianIndex{D},μ₀) where D = all(ntuple(i->(μ₀[I,i] ≤ 1f-6) & (μ₀[I+δ(i,I),i] ≤ 1f-6), Val(D)))
     R,ε,Tc = 8f0,0.25f0,64f0
     scale(t) = 1-ε*(1-cospi(2t/Tc))              # radius scale, ṡ(0)=0 for a smooth start
     dscale(t) = -2ε*Float32(π)/Tc*sinpi(2t/Tc)
@@ -196,7 +193,10 @@ end
         foreach(i->sim_step!(sim),1:8)
         a = sim.flow
         # the source must vanish where the operator is null, else the multigrid stalls
-        @inside a.σ[I] = closed_cell(I,a.μ₀) ? abs(WaterLily.div(I,a.u)-a.σᵥ[I]) : 0f0
+        # this is what happens inside mom_project!
+        a.σ .= 0.f0; @inside a.σ[I] = (1+WaterLily.diag(I,a.μ₀)/4)*WaterLily.div(I,a.V)
+        s = sum(a.σ)/length(inside(a.σ))
+        @inside a.σ[I] = closed_cell(I,a.μ₀) ? abs(WaterLily.div(I,a.u)-a.σ[I]+s) : 0f0
         @test maximum(a.σ) < 1f-2
         # and the body must still displace its own volume: the flux through a contour
         # enclosing it is dA/dt, less the uniform background a closed box forces on it

--- a/test/test_flow.jl
+++ b/test/test_flow.jl
@@ -177,3 +177,33 @@ end
         @test WaterLily.median(a,b,c) == sort([a,b,c])[2]
     end
 end
+
+@testset "Deforming body dilatation" begin
+    # A body whose volume changes has div(V)≠0, and BDIM sets u=V in every cell closed on
+    # all faces, so div(u)=div(V) there -- in rows whose Poisson diagonal is zero. `flow.σᵥ`
+    # carries that dilatation out of the source. Both halves matter: drop σᵥ and an
+    # irreducible residual is left behind, but subtract the body's flux div((1-μ₀)V) instead
+    # and the source telescopes to zero net volume, so the body stops displacing fluid.
+    closed_cell(I::CartesianIndex{D},μ₀) where D =
+        all(ntuple(i->(μ₀[I,i] ≤ 1f-6) & (μ₀[I+δ(i,I),i] ≤ 1f-6), Val(D)))
+    R,ε,Tc = 8f0,0.25f0,64f0
+    scale(t) = 1-ε*(1-cospi(2t/Tc))              # radius scale, ṡ(0)=0 for a smooth start
+    dscale(t) = -2ε*Float32(π)/Tc*sinpi(2t/Tc)
+    for f ∈ arrays
+        n = 64; c = SA_F32[n/2,n/2]
+        sim = Simulation((n,n),(0,0),2R;U=1,ν=2R/250,T=Float32,mem=f,
+                         body=AutoBody((x,t)->√(x'*x)-R,(x,t)->(x .- c)/scale(t)))
+        foreach(i->sim_step!(sim),1:8)
+        a = sim.flow
+        # the source must vanish where the operator is null, else the multigrid stalls
+        @inside a.σ[I] = closed_cell(I,a.μ₀) ? abs(WaterLily.div(I,a.u)-a.σᵥ[I]) : 0f0
+        @test maximum(a.σ) < 1f-2
+        # and the body must still displace its own volume: the flux through a contour
+        # enclosing it is dA/dt, less the uniform background a closed box forces on it
+        u = Array(a.u); t = sum(a.Δt); h = 12; k = n÷2
+        q = sum(u[k+h+1,j,1]-u[k-h,j,1] for j in k-h:k+h) +
+            sum(u[i,k+h+1,2]-u[i,k-h,2] for i in k-h:k+h)
+        dAdt = 2Float32(π)*R^2*scale(t)*dscale(t)*(1-(2h+1)^2/n^2)
+        @test 0.8 < q/dAdt < 1.3
+    end
+end


### PR DESCRIPTION
This PR is actually reviving something we removed a while ago (couldn't find the PR itself)

### Problem

A body that changes volume has `div(V) ≠ 0`, so those cells carry a divergence, but becuase those cells also have a zero Poisson coefficient, the poisson solver can never correct for that and stalls.

I though `residual!` would help, but it zeroes `r` where `iD==0`, then subtracts the mean **uniformly over every cell, including the ones it just zeroed** and after that `increment!` leaves these cells untouched (`D=0`, all `L=0`, so `mult ≡ 0`).
The shift `-s` is therefore frozen in these cells for the whole solve, giving a hard floor `L∞ ≥ |s|` against `r∞tol = 2e-3`. Any uncorrectable mean above that and the solve *cannot* converge: it runs to `itmx=32` every step. This is potentially a limit for rigid bodies as well.

### Fix

We need to remove this divergence where we cannot correct it (similar to what `flow.σᵥ` did before)
```julia
function mom_project!(a::AbstractFlow{D,T}, b::AbstractPoisson, w, t) where {D,T}
    dt = T(w)*a.Δt[end]; a.σ .= zero(T)
    # div(V)≠0 cannot be corrected inside the body, we must remove it
    @inside a.σ[I] = (1+diag(I,a.μ₀)/(2D))*div(I,a.V)
    # Remove the mean to avoid the pressure drifting
    s = sum(a.σ)/length(inside(a.σ)) # ghosts are never written, so the full sum is exact
    @inside b.z[I] = div(I,a.u)-a.σ[I]+s; b.x .*= dt # set source term & solution IC
    solver!(b)
    for i ∈ 1:ndims(a.p)  # apply solution and unscale to recover pressure
        @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)
    end
    b.x ./= dt
    BC!(a.u,a.uBC,a.exitBC,a.perdir,t)
end
```
Removing the mean is the important bit: it makes `residual!` hit its `abs(s) >= 2eps` early, so nothing is ever injected into the dead rows.

### Test
`test_flow.jl` implements a pulsating circle that checks that
1. no source survives where the operator is null (< 1e-2);
2. the body still displaces its own volume
This test fails on `master`.

Note: I think this is the reason why Zhihong had to use an old `fluid-structure` branch for his MSc project and not `master`; it still contained the old residual and body dilation term.